### PR TITLE
refactor: optimize spell data sync by sending full SpellBase in Playe…

### DIFF
--- a/apps/holtburger-cli/src/ui/update/mod.rs
+++ b/apps/holtburger-cli/src/ui/update/mod.rs
@@ -53,18 +53,6 @@ impl AppState {
         let mut commands = Vec::new();
         let now = std::time::Instant::now();
 
-        // Request spell info for spells we don't have info for yet
-        let mut missing_spells = Vec::new();
-        for &spell_id in &self.player_spells {
-            if !self.spell_info.contains_key(&spell_id) {
-                missing_spells.push(holtburger_core::ResourceDescriptor::Spell(spell_id));
-            }
-        }
-
-        if !missing_spells.is_empty() {
-            commands.push(ClientCommand::ResolveResources(missing_spells));
-        }
-
         // Update net stats
         let last_update = self.net_stats.last_update.get_or_insert(now);
         if now.duration_since(*last_update).as_secs() >= 1 {

--- a/apps/holtburger-cli/src/ui/update/world.rs
+++ b/apps/holtburger-cli/src/ui/update/world.rs
@@ -32,15 +32,6 @@ impl AppState {
                 self.player_guid = Some(guid);
                 self.character_name = Some(name);
             }
-            WireEvent::ResourcesResolved(resources) => {
-                for resource in resources {
-                    match resource {
-                        holtburger_core::ResolvedResource::Spell { spell_id, info } => {
-                            self.spell_info.insert(spell_id, info);
-                        }
-                    }
-                }
-            }
             WireEvent::ServerMessage(message) => {
                 self.log_chat(ChatMessageKind::System, message);
             }
@@ -153,14 +144,12 @@ impl AppState {
             }
             ClientViewEvent::PlayerSpellsUpdated {
                 spell_ids,
-                resolved,
+                spells,
             } => {
                 self.player_spells = spell_ids;
-                for summary in resolved {
-                    if let (id, Some(name)) = (summary.spell_id, summary.name) {
-                        self.spell_names.insert(id, name);
-                    }
-                    // We could also populate self.spell_info here if we added enough fields to ResolvedSpellSummary
+                for (id, info) in spells {
+                    self.spell_names.insert(id, info.name.clone());
+                    self.spell_info.insert(id, Box::new(info));
                 }
             }
             ClientViewEvent::EntityUpserted { entity } => {

--- a/crates/holtburger-core/src/client/commands.rs
+++ b/crates/holtburger-core/src/client/commands.rs
@@ -1,4 +1,4 @@
-use crate::client::types::{ClientCommand, ResolvedResource, ResourceDescriptor, WireEvent};
+use crate::client::types::ClientCommand;
 use crate::client::{Client, ClientState};
 use crate::world::StateEvent;
 use anyhow::Result;
@@ -25,8 +25,9 @@ impl Client {
             | ClientCommand::Use(_)
             | ClientCommand::UseWithTarget { .. }
             | ClientCommand::CastTargetedSpell { .. }
-            | ClientCommand::CastUntargetedSpell { .. }
-            | ClientCommand::ResolveResources(_) => self.handle_interaction_command(cmd).await,
+            | ClientCommand::CastUntargetedSpell { .. } => {
+                self.handle_interaction_command(cmd).await
+            }
 
             ClientCommand::Drop(_)
             | ClientCommand::Get(_)
@@ -185,25 +186,6 @@ impl Client {
                     CastUntargetedSpellData { spell_id },
                 )))
                 .await
-            }
-            ClientCommand::ResolveResources(descriptors) => {
-                let mut results = Vec::new();
-                for descriptor in descriptors {
-                    match descriptor {
-                        ResourceDescriptor::Spell(spell_id) => {
-                            if let Some(info) = self.world.resolve_spell_info(spell_id) {
-                                results.push(ResolvedResource::Spell {
-                                    spell_id,
-                                    info: Box::new(info),
-                                });
-                            }
-                        }
-                    }
-                }
-                if !results.is_empty() {
-                    self.emit_wire_event(WireEvent::ResourcesResolved(results));
-                }
-                Ok(())
             }
             _ => unreachable!(),
         }

--- a/crates/holtburger-core/src/client/mod.rs
+++ b/crates/holtburger-core/src/client/mod.rs
@@ -178,22 +178,10 @@ impl Client {
                 let mut spell_ids: Vec<u32> = self.world.player.spells.keys().cloned().collect();
                 spell_ids.sort();
 
-                let mut resolved = Vec::new();
+                let mut spells = HashMap::new();
                 for &spell_id in &spell_ids {
                     if let Some(spell) = self.world.resolve_spell_info(spell_id) {
-                        resolved.push(ResolvedSpellSummary {
-                            spell_id,
-                            name: Some(spell.name),
-                            school: Some(spell.school),
-                            icon: Some(spell.icon_id),
-                        });
-                    } else {
-                        resolved.push(ResolvedSpellSummary {
-                            spell_id,
-                            name: None,
-                            school: None,
-                            icon: None,
-                        });
+                        spells.insert(spell_id, spell);
                     }
                 }
 
@@ -201,7 +189,7 @@ impl Client {
                     .client_view_event_tx
                     .send(ClientViewEvent::PlayerSpellsUpdated {
                         spell_ids,
-                        resolved,
+                        spells,
                     });
             }
             StateEvent::PlayerInfo(_) => {

--- a/crates/holtburger-core/src/client/types.rs
+++ b/crates/holtburger-core/src/client/types.rs
@@ -74,15 +74,6 @@ pub enum WireEvent {
     UseDone {
         error_id: u32,
     },
-    ResourcesResolved(Vec<ResolvedResource>),
-}
-
-#[derive(Debug, Clone)]
-pub struct ResolvedSpellSummary {
-    pub spell_id: u32,
-    pub name: Option<String>,
-    pub school: Option<u32>,
-    pub icon: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -103,7 +94,7 @@ pub enum ClientViewEvent {
     },
     PlayerSpellsUpdated {
         spell_ids: Vec<u32>,
-        resolved: Vec<ResolvedSpellSummary>,
+        spells: HashMap<u32, holtburger_dat::file_type::spell_table::SpellBase>,
     },
     PlayerEnchantmentsUpdated {
         enchantments: Vec<Enchantment>,
@@ -130,19 +121,6 @@ pub enum ClientViewEvent {
     },
     NoClipUpdated {
         enabled: bool,
-    },
-}
-
-#[derive(Debug, Clone)]
-pub enum ResourceDescriptor {
-    Spell(u32),
-}
-
-#[derive(Debug, Clone)]
-pub enum ResolvedResource {
-    Spell {
-        spell_id: u32,
-        info: Box<holtburger_dat::file_type::spell_table::SpellBase>,
     },
 }
 
@@ -219,7 +197,6 @@ pub enum ClientCommand {
     CastUntargetedSpell {
         spell_id: u32,
     },
-    ResolveResources(Vec<ResourceDescriptor>),
     SetCombatMode(holtburger_protocol::messages::combat::CombatMode),
     SetNoClip(bool),
     CancelAttack,


### PR DESCRIPTION
This pull request removes the generic resource resolution mechanism for spells and simplifies how spell information is synchronized between the client and server. Instead of requesting missing spell info via a `ResolveResources` command and handling the response, the server now sends full spell info directly as part of the `PlayerSpellsUpdated` event. This reduces complexity and improves efficiency in how spell data is managed.

**Refactoring and simplification of spell info synchronization:**

* Removed the `ResolveResources` command and related types (`ResourceDescriptor`, `ResolvedResource`, `ResolvedSpellSummary`) from the codebase, eliminating the need for separate resource resolution requests and responses. [[1]](diffhunk://#diff-0797cb9b6cf5fafe49028b663e78d9e13558d2bc78570c9b31af200f071dce54L77-L85) [[2]](diffhunk://#diff-0797cb9b6cf5fafe49028b663e78d9e13558d2bc78570c9b31af200f071dce54L136-L148) [[3]](diffhunk://#diff-0797cb9b6cf5fafe49028b663e78d9e13558d2bc78570c9b31af200f071dce54L222) [[4]](diffhunk://#diff-36846f1dea6bc88af8b5a6e53de3c30f321a3f6508be5c92b1618554391c0c2bL1-R1) [[5]](diffhunk://#diff-36846f1dea6bc88af8b5a6e53de3c30f321a3f6508be5c92b1618554391c0c2bL28-R30) [[6]](diffhunk://#diff-36846f1dea6bc88af8b5a6e53de3c30f321a3f6508be5c92b1618554391c0c2bL189-L207)
* Updated the server logic so that when player spells are updated, the server sends a `PlayerSpellsUpdated` event containing a map of spell IDs to full spell info objects, rather than a list of summaries. [[1]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aL181-R192) [[2]](diffhunk://#diff-0797cb9b6cf5fafe49028b663e78d9e13558d2bc78570c9b31af200f071dce54L106-R97)
* Updated the client state update logic to directly populate both `spell_names` and `spell_info` from the new `spells` map in the `PlayerSpellsUpdated` event, removing the need to handle resource resolution responses.
* Removed the code that requested missing spell info and handled `ResourcesResolved` events from the client UI update logic, as this is now handled directly by the new spell update mechanism. [[1]](diffhunk://#diff-f7114b997209a84a9570bed8907da0c419a1985d27cfb81317b87d2ce1554680L56-L67) [[2]](diffhunk://#diff-090fc3199e26090ebd89815b6edf3812dcab0ca21fa30cbcefd5d56c9b6cccaeL35-L43)