### PR TITLE
fix duplicate keypresses in windows terminals

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -112,6 +112,7 @@
 - [x] Tabs should manage their own current index. E.g., should not be passed into `get_verbs()`. (SCRAPPED)
 - [x] Stacking/Splitting.
 - [x] Merging by ItemType is wrong! Lots of things share ItemTypes. WeenieIDs maybe?
+- [x] Keypresses are doubled under windows. According to google: "The issue of doubled keypresses in a Ratatui application on Windows is a known behavior of the underlying crossterm library, which fires both KeyPress and KeyRelease events (and sometimes KeyRepeat events) on Windows, whereas Mac/Linux only get KeyPress events. To fix this, you must explicitly filter your application's event loop to only process KeyEventKind::Press events."
 - [ ] DC detection + /reconnect command.
 - [ ] Augment assess output with entity properties.
 - [ ] Melee combat.
@@ -130,7 +131,6 @@
     - E.g., Sell/Buy action puts client in "busy" state, waiting for UseDone to clear it and we can raise an event that a Sell/Buy completed + error code.
     - But sometimes UseDone comes with no error code even if the interaction fails, so lib can also look for WeenieErrors that DNShappen right before the UseDone and pass that along.
 - [ ] Crafting.
-- [ ] Keypresses are doubled under windows. According to google: "The issue of doubled keypresses in a Ratatui application on Windows is a known behavior of the underlying crossterm library, which fires both KeyPress and KeyRelease events (and sometimes KeyRepeat events) on Windows, whereas Mac/Linux only get KeyPress events. To fix this, you must explicitly filter your application's event loop to only process KeyEventKind::Press events."
 - [ ] Should split into the same container.
 - [ ] Precise splitting.
 

--- a/apps/holtburger-cli/src/bin/tui.rs
+++ b/apps/holtburger-cli/src/bin/tui.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event},
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -303,6 +303,10 @@ async fn main() -> Result<()> {
             while event::poll(std::time::Duration::from_millis(0))? {
                 match event::read()? {
                     Event::Key(key) => {
+                        if key.kind != KeyEventKind::Press {
+                            continue;
+                        }
+
                         let size = terminal.size()?;
                         let (_, main_chunks, dynamic_chunk) = ui::get_layout(size);
                         let res = app_state.handle_action(ui::AppAction::KeyPress(


### PR DESCRIPTION
This pull request updates the `TODO.md` file to mark the issue of doubled keypresses on Windows as completed. The change reflects that the problem—caused by the underlying `crossterm` library firing extra key events on Windows—has been addressed by filtering for `KeyEventKind::Press` events in the application's event loop.

- Task completion:
  * Marked the Windows doubled keypresses issue as completed, with a note explaining the cause and solution involving filtering for `KeyEventKind::Press` events. [[1]](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986R115) [[2]](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986L133)