### PR TITLE
Refactor property accessors to trait in holtburger-common

### DIFF
--- a/apps/holtburger-cli/src/pages/game/data.rs
+++ b/apps/holtburger-cli/src/pages/game/data.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use holtburger_common::Guid;
+use holtburger_common::properties::WorldObjectExt as _;
 use holtburger_common::position::WorldPosition;
 use holtburger_protocol::messages::EquipMask;
 use holtburger_protocol::messages::combat::CombatMode;

--- a/apps/holtburger-cli/src/pages/game/panels/dashboard/assess.rs
+++ b/apps/holtburger-cli/src/pages/game/panels/dashboard/assess.rs
@@ -1,4 +1,6 @@
-use holtburger_common::properties::{PropertyInt, PropertyString, WorldObjectPropertyAccessors};
+use holtburger_common::properties::{
+    PropertyInt, PropertyString, WorldObjectExt as _, WorldObjectPropertyAccessors,
+};
 use holtburger_world::entity::Entity;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -36,13 +38,16 @@ pub fn get_assess_info(entity: &Entity) -> Vec<Line<'static>> {
     }
 
     // Basic Stats
-    if let Some(value) = entity.get_int_prop(PropertyInt::Value) {
+    if entity.item_value() > 0 {
         lines.push(Line::from(vec![
             Span::styled("Value:  ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format!("{}", value), Style::default().fg(Color::White)),
+            Span::styled(
+                format!("{}", entity.item_value()),
+                Style::default().fg(Color::White),
+            ),
         ]));
     }
-    if let Some(burden) = entity.get_int_prop(PropertyInt::EncumbranceVal) {
+    if let Some(burden) = entity.burden() {
         lines.push(Line::from(vec![
             Span::styled("Burden: ", Style::default().fg(Color::DarkGray)),
             Span::styled(format!("{}bu", burden), Style::default().fg(Color::White)),

--- a/apps/holtburger-cli/src/pages/game/panels/dashboard/debug.rs
+++ b/apps/holtburger-cli/src/pages/game/panels/dashboard/debug.rs
@@ -4,7 +4,7 @@ use crate::pages::game::ViewState;
 use crate::types::CommandTarget;
 use holtburger_common::Guid;
 use holtburger_common::properties::{
-    EnchantmentTypeFlags, PropertyFloat, PropertyInt, PropertyString,
+    EnchantmentTypeFlags, PropertyFloat, PropertyInt, WorldObjectExt,
 };
 use holtburger_protocol::messages::magic::Enchantment;
 use holtburger_world::stats::{Attribute, AttributeType, Skill, SkillType, Vital, VitalType};
@@ -39,22 +39,9 @@ pub fn get_debug_info(
             else {
                 return lines;
             };
-            let name = v
-                .properties
-                .strings
-                .get(&PropertyString::Name)
-                .cloned()
-                .unwrap_or_else(|| "Unknown".to_string());
-            let value = v
-                .properties
-                .ints
-                .get(&PropertyInt::Value)
-                .copied()
-                .unwrap_or(0);
-
-            lines.push(Line::from(format!("DEBUG VENDOR ITEM: {}", name)));
+            lines.push(Line::from(format!("DEBUG VENDOR ITEM: {}", v.name())));
             lines.push(Line::from(format!("GUID:   {:08X}", v.guid)));
-            lines.push(Line::from(format!("Value:  {}", value)));
+            lines.push(Line::from(format!("Value:  {}", v.item_value())));
             lines.push(Line::from(format!("WCID:   {}", v.wcid)));
         }
         CommandTarget::Entity(guid) | CommandTarget::EntityWithSlot(guid, _) => {

--- a/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/classification.rs
+++ b/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/classification.rs
@@ -1,5 +1,6 @@
 use holtburger_common::properties::{
-    ItemType, ObjectDescriptionFlag, PropertyBool, PropertyInt, WorldObjectProperties,
+    ItemType, ObjectDescriptionFlag, PropertyBool, PropertyInt, WorldObjectExt,
+    WorldObjectProperties, WorldObjectPropertyAccessors,
 };
 use holtburger_protocol::messages::object::messages::PublicWeenieDescription;
 use holtburger_world::entity::Entity;
@@ -108,7 +109,7 @@ pub fn get_entity_color(class: EntityClass) -> Color {
 }
 
 pub fn classify_entity(entity: &Entity) -> EntityClass {
-    classify_raw(entity.flags, entity.item_type())
+    classify_world_object(entity.flags, entity)
 }
 
 pub fn classify_vendor_item(item: &CoreVendorItem) -> EntityClass {
@@ -116,15 +117,9 @@ pub fn classify_vendor_item(item: &CoreVendorItem) -> EntityClass {
 }
 
 pub fn classify_properties(props: &WorldObjectProperties) -> EntityClass {
-    let item_type = props
-        .ints
-        .get(&PropertyInt::ItemType)
-        .map(|v| ItemType::from_bits_truncate(*v as u32));
-
     let physics_state = props
-        .ints
-        .get(&PropertyInt::PhysicsState)
-        .map(|v| holtburger_common::properties::PhysicsState::from_bits_truncate(*v as u32))
+        .get_int_prop(PropertyInt::PhysicsState)
+        .map(|v| holtburger_common::properties::PhysicsState::from_bits_truncate(v as u32))
         .unwrap_or(holtburger_common::properties::PhysicsState::empty());
 
     // Let's create dummy flags for classify_raw based on what we know.
@@ -132,26 +127,16 @@ pub fn classify_properties(props: &WorldObjectProperties) -> EntityClass {
     if physics_state.contains(holtburger_common::properties::PhysicsState::STATIC) {
         flags |= ObjectDescriptionFlag::STUCK;
     }
-    if props
-        .bools
-        .get(&PropertyBool::Stuck)
-        .copied()
-        .unwrap_or(false)
-    {
+    if props.is_stuck() {
         flags |= ObjectDescriptionFlag::STUCK;
     }
-    if props
-        .bools
-        .get(&PropertyBool::Attackable)
-        .copied()
-        .unwrap_or(false)
-    {
+    if props.get_bool_prop(PropertyBool::Attackable) {
         flags |= ObjectDescriptionFlag::ATTACKABLE;
     }
     // Note: ItemType does not have a PLAYER flag, it's in ObjectDescriptionFlag.
     // We can't easily deduce it from properties alone unless we have a specific property.
 
-    classify_raw(flags, item_type)
+    classify_world_object(flags, props)
 }
 
 pub fn classify_description(desc: &PublicWeenieDescription) -> EntityClass {
@@ -265,4 +250,11 @@ fn classify_raw(flags: ObjectDescriptionFlag, item_type: Option<ItemType>) -> En
     }
 
     EntityClass::Unknown
+}
+
+fn classify_world_object<T: WorldObjectExt>(
+    flags: ObjectDescriptionFlag,
+    object: &T,
+) -> EntityClass {
+    classify_raw(flags, object.item_type())
 }

--- a/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/equip/render.rs
+++ b/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/equip/render.rs
@@ -9,7 +9,7 @@ use super::tab::EquipTab;
 use crate::pages::game::{GameData, ViewState};
 use crate::theme;
 use crate::utils::format_item_name;
-use holtburger_common::properties::{EquipMask, PseudoEquipMask};
+use holtburger_common::properties::{EquipMask, PseudoEquipMask, WorldObjectExt as _};
 use holtburger_core::client::types::TargetSlot;
 use holtburger_world::entity::Entity;
 

--- a/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/inventory/render.rs
+++ b/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/inventory/render.rs
@@ -10,7 +10,7 @@ use crate::pages::game::{GameData, ViewState};
 use crate::theme;
 use crate::utils::format_item_name;
 use holtburger_common::Guid;
-use holtburger_common::properties::{EquipMask, ItemType};
+use holtburger_common::properties::{EquipMask, ItemType, WorldObjectExt as _};
 use holtburger_world::context::WorldContextExt;
 use holtburger_world::crafting::salvage::get_material_name;
 use holtburger_world::entity::Entity;

--- a/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/inventory/tab.rs
+++ b/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/inventory/tab.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crossterm::event::{KeyCode, KeyEvent};
 use holtburger_common::Guid;
-use holtburger_common::properties::{ItemType, ObjectDescriptionFlag};
+use holtburger_common::properties::{ItemType, ObjectDescriptionFlag, WorldObjectExt as _};
 use holtburger_world::context::{WorldContext, WorldContextExt};
 use holtburger_world::entity::Entity;
 use ratatui::Frame;

--- a/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/nearby/render.rs
+++ b/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/nearby/render.rs
@@ -8,7 +8,7 @@ use super::tab::NearbyTab;
 use crate::pages::game::{GameData, ViewState};
 use crate::theme;
 use crate::utils::format_item_name;
-use holtburger_common::properties::WorldObjectPropertyAccessors;
+use holtburger_common::properties::WorldObjectExt as _;
 use holtburger_world::context::WorldContextExt;
 use holtburger_world::entity::Entity;
 
@@ -80,7 +80,7 @@ fn render_nearby_item(
 
     let mut display_name = format_item_name(e, e.guid);
 
-    if e.get_bool_prop(holtburger_common::properties::PropertyBool::Locked) {
+    if e.is_locked() {
         display_name = format!("{} [Locked]", display_name);
     }
 

--- a/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/nearby/tab.rs
+++ b/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/nearby/tab.rs
@@ -3,7 +3,7 @@ use std::vec;
 
 use crossterm::event::{KeyCode, KeyEvent};
 use holtburger_common::Guid;
-use holtburger_common::properties::PseudoEquipMask;
+use holtburger_common::properties::{PseudoEquipMask, WorldObjectExt as _};
 use holtburger_world::context::{WorldContext, WorldContextExt};
 use holtburger_world::entity::Entity;
 use ratatui::Frame;

--- a/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/trade/render.rs
+++ b/apps/holtburger-cli/src/pages/game/panels/dashboard/tabs/trade/render.rs
@@ -11,7 +11,7 @@ use crate::theme;
 use crate::types::TradeFocus;
 use crate::utils::format_item_name;
 use holtburger_common::defaults::{DEFAULT_PRICE, PROMISSORY_NOTE_SELL_RATE, VENDOR_CEIL_OFFSET};
-use holtburger_common::properties::{ItemType, PropertyInt};
+use holtburger_common::properties::{ItemType, PropertyInt, WorldObjectExt as _};
 use holtburger_world::context::WorldContextExt;
 
 pub fn render_trade_tab(

--- a/apps/holtburger-cli/src/pages/game/panels/dynamic.rs
+++ b/apps/holtburger-cli/src/pages/game/panels/dynamic.rs
@@ -1,6 +1,7 @@
 use crate::pages::game::{GameData, ViewState};
 use crate::theme::{pane_block, pane_title_style};
 use crate::types::{FocusedPane, Interaction};
+use holtburger_common::properties::WorldObjectExt as _;
 use holtburger_world::crafting::salvage::{SalvagePreviewBag, get_material_name};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};

--- a/apps/holtburger-cli/src/pages/game/salvaging.rs
+++ b/apps/holtburger-cli/src/pages/game/salvaging.rs
@@ -1,7 +1,9 @@
 use super::GameData;
 use holtburger_common::Guid;
 use holtburger_common::properties::ItemType;
-use holtburger_common::properties::{PropertyInt, WorldObjectPropertyAccessors};
+use holtburger_common::properties::{
+    PropertyInt, WorldObjectExt as _, WorldObjectPropertyAccessors,
+};
 use holtburger_world::context::WorldContextExt;
 use holtburger_world::crafting::salvage::{
     SalvageItemInput, SalvageSkillProfile, best_trained_tinkering_skill, predict_salvage_preview,

--- a/apps/holtburger-cli/src/pages/game/state.rs
+++ b/apps/holtburger-cli/src/pages/game/state.rs
@@ -16,6 +16,7 @@ use crate::types::{
     AppAction, AppUiAction, ChatMessageKind, ContextView, DashboardTab, FocusedPane, Interaction,
     UpdateResult,
 };
+use holtburger_common::properties::WorldObjectExt as _;
 
 #[derive(Default)]
 pub struct GameState {

--- a/apps/holtburger-cli/src/types.rs
+++ b/apps/holtburger-cli/src/types.rs
@@ -5,6 +5,7 @@ use crate::pages::selection::SelectionState;
 use crate::state::RenderContext;
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 use holtburger_common::Guid;
+use holtburger_common::properties::WorldObjectExt as _;
 use holtburger_core::client::types::TargetSlot;
 use holtburger_core::{ClientCommand, ClientViewEvent};
 use holtburger_protocol::messages::combat::CombatMode;

--- a/apps/holtburger-cli/src/utils.rs
+++ b/apps/holtburger-cli/src/utils.rs
@@ -1,13 +1,11 @@
 use crate::types::FocusedPane;
 use holtburger_common::Guid;
-use holtburger_common::properties::{PropertyInt, PropertyString, WorldObjectPropertyAccessors, ItemType};
+use holtburger_common::properties::{ItemType, WorldObjectExt};
 use unicode_width::UnicodeWidthStr;
 
 /// Formats an item's display name, including stack size and structure/durability if present.
-pub fn format_item_name<T: WorldObjectPropertyAccessors>(item: &T, guid: Guid) -> String {
-    let name = item
-        .get_string_prop(PropertyString::Name)
-        .unwrap_or("Unknown");
+pub fn format_item_name<T: WorldObjectExt>(item: &T, guid: Guid) -> String {
+    let name = item.name();
     let mut display_name = if name.trim().is_empty() {
         format!("<{}>", guid)
     } else {
@@ -16,20 +14,20 @@ pub fn format_item_name<T: WorldObjectPropertyAccessors>(item: &T, guid: Guid) -
 
     // Strip out count suffix from salvage bags since we append our own structure suffix.
     let is_salvage = item
-        .get_int_prop(PropertyInt::ItemType)
-        .is_some_and(|bits| ItemType::from_bits(bits as u32).unwrap_or_default().contains(ItemType::TINKERING_MATERIAL));
+        .item_type()
+        .is_some_and(|item_type| item_type.contains(ItemType::TINKERING_MATERIAL));
     if is_salvage
         && let Some(idx) = display_name.rfind(" (") {
             display_name.truncate(idx);
         }
 
-    let stack_size = item.get_int_prop(PropertyInt::StackSize).unwrap_or(1);
+    let stack_size = item.stack_size();
     if stack_size > 1 {
         display_name = format!("{} ({}x)", display_name, stack_size);
     }
 
-    let structure = item.get_int_prop(PropertyInt::Structure);
-    let max_structure = item.get_int_prop(PropertyInt::MaxStructure);
+    let structure = item.structure();
+    let max_structure = item.max_structure();
 
     if let (Some(s), Some(ms)) = (structure, max_structure) {
         display_name = format!("{} ({}/{})", display_name, s, ms);

--- a/crates/holtburger-common/src/properties.rs
+++ b/crates/holtburger-common/src/properties.rs
@@ -1683,6 +1683,295 @@ pub trait WorldObjectPropertyAccessors: HasProperties {
     }
 }
 
+pub trait WorldObjectExt: WorldObjectPropertyAccessors {
+    fn item_type(&self) -> Option<ItemType> {
+        self.get_int_prop(PropertyInt::ItemType)
+            .and_then(|val| ItemType::from_bits(val as u32))
+    }
+
+    fn container_id(&self) -> Option<Guid> {
+        self.get_instance_prop(PropertyInstanceId::Container)
+    }
+
+    fn wielder_id(&self) -> Option<Guid> {
+        self.get_instance_prop(PropertyInstanceId::Wielder)
+    }
+
+    fn is_root(&self) -> bool {
+        self.container_id().is_none() && self.wielder_id().is_none()
+    }
+
+    fn item_value(&self) -> u32 {
+        self.get_int_prop(PropertyInt::Value).unwrap_or(0) as u32
+    }
+
+    fn items_capacity(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::ItemsCapacity)
+            .map(|v| v as u32)
+    }
+
+    fn containers_capacity(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::ContainersCapacity)
+            .map(|v| v as u32)
+    }
+
+    fn stack_size(&self) -> u32 {
+        self.get_int_prop(PropertyInt::StackSize).unwrap_or(1) as u32
+    }
+
+    fn is_stackable(&self) -> bool {
+        self.get_int_prop(PropertyInt::MaxStackSize).unwrap_or(0) > 1
+    }
+
+    fn plural_name(&self) -> Option<&str> {
+        self.get_string_prop(PropertyString::PluralName)
+    }
+
+    fn obj_scale(&self) -> Option<f64> {
+        self.get_float_prop(PropertyFloat::DefaultScale)
+    }
+
+    fn friction(&self) -> Option<f64> {
+        self.get_float_prop(PropertyFloat::Friction)
+    }
+
+    fn elasticity(&self) -> Option<f64> {
+        self.get_float_prop(PropertyFloat::Elasticity)
+    }
+
+    fn translucency(&self) -> Option<f64> {
+        self.get_float_prop(PropertyFloat::Translucency)
+    }
+
+    fn mass(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::Mass).map(|v| v as u32)
+    }
+
+    fn workmanship(&self) -> Option<f64> {
+        self.get_int_prop(PropertyInt::ItemWorkmanship)
+            .map(|v| v as f64)
+    }
+
+    fn burden(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::EncumbranceVal)
+            .map(|v| v as u32)
+    }
+
+    fn item_type_int(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::ItemType).map(|v| v as u32)
+    }
+
+    fn ammo_type(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::AmmoType).map(|v| v as u32)
+    }
+
+    fn usable(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::ItemUseable).map(|v| v as u32)
+    }
+
+    fn use_radius(&self) -> Option<f64> {
+        self.get_float_prop(PropertyFloat::UseRadius)
+    }
+
+    fn target_type(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::TargetType).map(|v| v as u32)
+    }
+
+    fn target_item_type(&self) -> Option<ItemType> {
+        self.target_type().and_then(ItemType::from_bits)
+    }
+
+    fn ui_effects(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::UiEffects).map(|v| v as u32)
+    }
+
+    fn combat_use(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::CombatUse).map(|v| v as u32)
+    }
+
+    fn structure(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::Structure).map(|v| v as u32)
+    }
+
+    fn max_structure(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::MaxStructure)
+            .map(|v| v as u32)
+    }
+
+    fn max_stack_size(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::MaxStackSize)
+            .map(|v| v as u32)
+    }
+
+    fn priority(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::ClothingPriority)
+            .map(|v| v as u32)
+    }
+
+    fn radar_blip_color(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::RadarBlipColor)
+            .map(|v| v as u32)
+    }
+
+    fn radar_enum(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::ShowableOnRadar)
+            .map(|v| v as u32)
+    }
+
+    fn pscript(&self) -> Option<Guid> {
+        self.get_data_prop(PropertyDataId::PhysicsScript)
+    }
+
+    fn spell(&self) -> Option<Guid> {
+        self.get_data_prop(PropertyDataId::Spell)
+    }
+
+    fn cooldown_id(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::SharedCooldown)
+            .map(|v| v as u32)
+    }
+
+    fn cooldown_duration(&self) -> Option<f64> {
+        self.get_float_prop(PropertyFloat::CooldownDuration)
+    }
+
+    fn mtable_id(&self) -> Option<Guid> {
+        self.get_data_prop(PropertyDataId::MotionTable)
+    }
+
+    fn stable_id(&self) -> Option<Guid> {
+        self.get_data_prop(PropertyDataId::SoundTable)
+    }
+
+    fn petable_id(&self) -> Option<Guid> {
+        self.get_data_prop(PropertyDataId::PhysicsEffectTable)
+    }
+
+    fn csetup_id(&self) -> Option<Guid> {
+        self.get_data_prop(PropertyDataId::Setup)
+    }
+
+    fn default_script_id(&self) -> Option<Guid> {
+        self.get_data_prop(PropertyDataId::PhysicsScript)
+    }
+
+    fn default_script_intensity(&self) -> Option<f64> {
+        self.get_float_prop(PropertyFloat::PhysicsScriptIntensity)
+    }
+
+    fn house_owner_id(&self) -> Option<Guid> {
+        self.get_instance_prop(PropertyInstanceId::HouseOwner)
+    }
+
+    fn monarch_id(&self) -> Option<Guid> {
+        self.get_instance_prop(PropertyInstanceId::Monarch)
+    }
+
+    fn pet_owner_id(&self) -> Option<Guid> {
+        self.get_instance_prop(PropertyInstanceId::PetOwner)
+    }
+
+    fn icon_overlay_id(&self) -> Option<Guid> {
+        self.get_data_prop(PropertyDataId::IconOverlay)
+    }
+
+    fn icon_underlay_id(&self) -> Option<Guid> {
+        self.get_data_prop(PropertyDataId::IconUnderlay)
+    }
+
+    fn material_type(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::MaterialType)
+            .map(|v| v as u32)
+    }
+
+    fn hook_type(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::HookType).map(|v| v as u32)
+    }
+
+    fn hook_item_types(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::HookItemType)
+            .map(|v| v as u32)
+    }
+
+    fn hook_placement(&self) -> Option<u32> {
+        self.get_int_prop(PropertyInt::HookPlacement)
+            .map(|v| v as u32)
+    }
+
+    fn valid_locations(&self) -> EquipMask {
+        EquipMask::from_bits_truncate(self.get_int_prop(PropertyInt::ValidLocations).unwrap_or(0) as u32)
+    }
+
+    fn wield_location(&self) -> EquipMask {
+        EquipMask::from_bits_truncate(
+            self.get_int_prop(PropertyInt::CurrentWieldedLocation)
+                .unwrap_or(0) as u32,
+        )
+    }
+
+    fn attuned_status(&self) -> AttunedStatus {
+        match self.get_int_prop(PropertyInt::Attuned) {
+            Some(1) => AttunedStatus::Attuned,
+            Some(2) => AttunedStatus::Sticky,
+            _ => AttunedStatus::Normal,
+        }
+    }
+
+    fn is_stuck(&self) -> bool {
+        self.get_bool_prop(PropertyBool::Stuck)
+    }
+
+    fn is_locked(&self) -> bool {
+        self.get_bool_prop(PropertyBool::Locked)
+    }
+
+    fn is_retained(&self) -> bool {
+        self.get_bool_prop(PropertyBool::Retained)
+    }
+
+    fn is_attuned_sticky(&self) -> bool {
+        self.attuned_status() != AttunedStatus::Normal
+    }
+
+    fn is_sellable(&self) -> bool {
+        self.properties()
+            .bools
+            .get(&PropertyBool::IsSellable)
+            .copied()
+            .unwrap_or(true)
+    }
+
+    fn is_tradable(&self) -> bool {
+        let attuned = self.attuned_status();
+        if attuned != AttunedStatus::Normal {
+            return false;
+        }
+
+        if self.get_int_prop(PropertyInt::PetClass).is_some()
+            && let Some(pet_guid) = self.get_instance_prop(PropertyInstanceId::Pet)
+            && !pet_guid.is_null()
+        {
+            return false;
+        }
+
+        true
+    }
+
+    fn name(&self) -> &str {
+        self.get_string_prop(PropertyString::Name)
+            .unwrap_or("Unknown")
+    }
+
+    fn can_hold_items(&self) -> bool {
+        self.items_capacity().unwrap_or(0) > 0
+    }
+
+    fn has_active_pet(&self) -> bool {
+        self.get_instance_prop(PropertyInstanceId::Pet)
+            .is_some_and(|id| id != Guid::NULL)
+    }
+}
+
 pub trait WorldObjectPropertyAccessorsMut: HasPropertiesMut {
     fn set_int_prop(&mut self, prop: PropertyInt, val: i32) {
         self.properties_mut().apply(PropertyUpdate::Int(prop, val));
@@ -1719,6 +2008,7 @@ pub trait WorldObjectPropertyAccessorsMut: HasPropertiesMut {
 }
 
 impl<T: HasProperties> WorldObjectPropertyAccessors for T {}
+impl<T: WorldObjectPropertyAccessors> WorldObjectExt for T {}
 impl<T: HasPropertiesMut> WorldObjectPropertyAccessorsMut for T {}
 
 impl HasProperties for WorldObjectProperties {

--- a/crates/holtburger-core/src/client/commands.rs
+++ b/crates/holtburger-core/src/client/commands.rs
@@ -1,7 +1,7 @@
 use crate::client::types::{ClientCommand, TargetSlot};
 use crate::client::{Client, ClientState};
 use anyhow::Result;
-use holtburger_common::properties::{EquipMask, PseudoEquipMask};
+use holtburger_common::properties::{EquipMask, PseudoEquipMask, WorldObjectExt as _};
 use holtburger_common::{Guid, Quaternion};
 use holtburger_protocol::messages::game_action::*;
 use holtburger_protocol::messages::game_message::{GameMessage, RawMotionFlags, RawMotionState};

--- a/crates/holtburger-core/src/client/messages.rs
+++ b/crates/holtburger-core/src/client/messages.rs
@@ -1,5 +1,6 @@
 use super::{Client, types::*};
 use anyhow::Result;
+use holtburger_common::properties::WorldObjectExt as _;
 use holtburger_common::sequence::is_newer_u16;
 use holtburger_protocol::messages::*;
 use holtburger_protocol::traits::ProtocolUnpack;

--- a/crates/holtburger-world/src/context.rs
+++ b/crates/holtburger-world/src/context.rs
@@ -1,7 +1,7 @@
 use crate::entity::Entity;
 use crate::vendor::VendorState;
 use holtburger_common::Guid;
-use holtburger_common::properties::{ItemType, PropertyBool, WorldObjectPropertyAccessors};
+use holtburger_common::properties::{ItemType, WorldObjectExt};
 use holtburger_protocol::messages::combat::CombatMode;
 
 /// Provides access to the world state for common logic.
@@ -173,7 +173,7 @@ pub trait WorldContextExt: WorldContext {
             return false;
         };
 
-        if entity.get_bool_prop(PropertyBool::Retained) {
+        if entity.is_retained() {
             return false;
         }
 

--- a/crates/holtburger-world/src/crafting/salvage.rs
+++ b/crates/holtburger-world/src/crafting/salvage.rs
@@ -1,6 +1,6 @@
 use crate::entity::Entity;
 use crate::stats::{Skill, SkillType, TrainingLevel};
-use holtburger_common::properties::{ItemType, PropertyInt, WorldObjectPropertyAccessors};
+use holtburger_common::properties::{ItemType, PropertyInt, WorldObjectExt};
 
 const MAX_SALVAGE_BAG_UNITS: u32 = 100;
 
@@ -43,7 +43,7 @@ struct WorkingBag {
 }
 
 impl SalvageItemInput {
-    pub fn from_entity(entity: &Entity) -> Option<Self> {
+    pub fn from_world_object<T: WorldObjectExt>(entity: &T) -> Option<Self> {
         Some(Self {
             item_type: entity.item_type()?,
             material_type: entity.material_type()?,
@@ -55,6 +55,10 @@ impl SalvageItemInput {
                 .unwrap_or(1)
                 .max(1) as u32,
         })
+    }
+
+    pub fn from_entity(entity: &Entity) -> Option<Self> {
+        Self::from_world_object(entity)
     }
 
     pub fn average_workmanship(&self) -> f64 {

--- a/crates/holtburger-world/src/entity.rs
+++ b/crates/holtburger-world/src/entity.rs
@@ -1,10 +1,9 @@
 use crate::hydration::WorldObjectPropertiesHydrationExt;
 use holtburger_common::position::WorldPosition;
 use holtburger_common::properties::{
-    AttunedStatus, EquipMask, HasProperties, HasPropertiesMut, ItemType, ObjectDescriptionFlag,
-    PhysicsState, PropertyBool, PropertyDataId, PropertyFloat, PropertyInstanceId, PropertyInt,
-    PropertyString, PropertyUpdate, WeenieHeaderFlag, WeenieHeaderFlag2, WorldObjectProperties,
-    WorldObjectPropertyAccessors, WorldObjectPropertyAccessorsMut,
+    HasProperties, HasPropertiesMut, ObjectDescriptionFlag, PhysicsState, PropertyInstanceId,
+    PropertyInt, PropertyString, PropertyUpdate, WeenieHeaderFlag, WeenieHeaderFlag2,
+    WorldObjectProperties, WorldObjectPropertyAccessorsMut,
 };
 use holtburger_common::{Guid, Vector3};
 use holtburger_protocol::messages::object::messages::description::ObjectDescriptionData;
@@ -50,13 +49,6 @@ pub struct Entity {
     pub resist_color: Option<u16>,
 }
 
-impl Entity {
-    pub fn item_type(&self) -> Option<ItemType> {
-        self.get_int_prop(PropertyInt::ItemType)
-            .and_then(|val| ItemType::from_bits(val as u32))
-    }
-}
-
 impl HasProperties for Entity {
     fn properties(&self) -> &WorldObjectProperties {
         &self.properties
@@ -74,256 +66,12 @@ impl Entity {
         self.properties.apply(update);
     }
 
-    pub fn container_id(&self) -> Option<Guid> {
-        self.get_instance_prop(PropertyInstanceId::Container)
-    }
-
     pub fn set_container_id(&mut self, val: Option<Guid>) {
         self.set_iid_prop(PropertyInstanceId::Container, val.unwrap_or(Guid::NULL))
     }
 
-    pub fn wielder_id(&self) -> Option<Guid> {
-        self.get_instance_prop(PropertyInstanceId::Wielder)
-    }
-
     pub fn set_wielder_id(&mut self, val: Option<Guid>) {
         self.set_iid_prop(PropertyInstanceId::Wielder, val.unwrap_or(Guid::NULL))
-    }
-
-    pub fn is_root(&self) -> bool {
-        self.container_id().is_none() && self.wielder_id().is_none()
-    }
-
-    pub fn item_value(&self) -> u32 {
-        self.get_int_prop(PropertyInt::Value).unwrap_or(0) as u32
-    }
-
-    pub fn items_capacity(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::ItemsCapacity)
-            .map(|v| v as u32)
-    }
-
-    pub fn containers_capacity(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::ContainersCapacity)
-            .map(|v| v as u32)
-    }
-
-    pub fn stack_size(&self) -> u32 {
-        self.get_int_prop(PropertyInt::StackSize).unwrap_or(1) as u32
-    }
-
-    pub fn is_stackable(&self) -> bool {
-        self.get_int_prop(PropertyInt::MaxStackSize).unwrap_or(0) > 1
-    }
-
-    pub fn plural_name(&self) -> Option<&str> {
-        self.get_string_prop(PropertyString::PluralName)
-    }
-
-    pub fn obj_scale(&self) -> Option<f64> {
-        self.get_float_prop(PropertyFloat::DefaultScale)
-    }
-
-    pub fn friction(&self) -> Option<f64> {
-        self.get_float_prop(PropertyFloat::Friction)
-    }
-
-    pub fn elasticity(&self) -> Option<f64> {
-        self.get_float_prop(PropertyFloat::Elasticity)
-    }
-
-    pub fn translucency(&self) -> Option<f64> {
-        self.get_float_prop(PropertyFloat::Translucency)
-    }
-
-    pub fn mass(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::Mass).map(|v| v as u32)
-    }
-
-    pub fn workmanship(&self) -> Option<f64> {
-        self.get_int_prop(PropertyInt::ItemWorkmanship)
-            .map(|v| v as f64)
-    }
-
-    pub fn burden(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::EncumbranceVal)
-            .map(|v| v as u32)
-    }
-
-    pub fn item_type_int(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::ItemType).map(|v| v as u32)
-    }
-
-    pub fn ammo_type(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::AmmoType).map(|v| v as u32)
-    }
-
-    pub fn usable(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::ItemUseable)
-            .map(|v| v as u32)
-    }
-
-    pub fn use_radius(&self) -> Option<f64> {
-        self.get_float_prop(PropertyFloat::UseRadius)
-    }
-
-    pub fn target_type(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::TargetType).map(|v| v as u32)
-    }
-
-    pub fn target_item_type(&self) -> Option<ItemType> {
-        self.target_type().and_then(ItemType::from_bits)
-    }
-
-    pub fn ui_effects(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::UiEffects).map(|v| v as u32)
-    }
-
-    pub fn combat_use(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::CombatUse).map(|v| v as u32)
-    }
-
-    pub fn structure(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::Structure).map(|v| v as u32)
-    }
-
-    pub fn max_structure(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::MaxStructure)
-            .map(|v| v as u32)
-    }
-
-    pub fn max_stack_size(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::MaxStackSize)
-            .map(|v| v as u32)
-    }
-
-    pub fn priority(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::ClothingPriority)
-            .map(|v| v as u32)
-    }
-
-    pub fn radar_blip_color(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::RadarBlipColor)
-            .map(|v| v as u32)
-    }
-
-    pub fn radar_enum(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::ShowableOnRadar)
-            .map(|v| v as u32)
-    }
-
-    pub fn pscript(&self) -> Option<Guid> {
-        self.get_data_prop(PropertyDataId::PhysicsScript)
-    }
-
-    pub fn spell(&self) -> Option<Guid> {
-        // ACE uses PropertyDataId.Spell for casting property?
-        self.get_data_prop(PropertyDataId::Spell)
-    }
-
-    pub fn cooldown_id(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::SharedCooldown)
-            .map(|v| v as u32)
-    }
-
-    pub fn cooldown_duration(&self) -> Option<f64> {
-        self.get_float_prop(PropertyFloat::CooldownDuration)
-    }
-
-    pub fn mtable_id(&self) -> Option<Guid> {
-        self.get_data_prop(PropertyDataId::MotionTable)
-    }
-
-    pub fn stable_id(&self) -> Option<Guid> {
-        self.get_data_prop(PropertyDataId::SoundTable)
-    }
-
-    pub fn petable_id(&self) -> Option<Guid> {
-        self.get_data_prop(PropertyDataId::PhysicsEffectTable)
-    }
-
-    pub fn csetup_id(&self) -> Option<Guid> {
-        self.get_data_prop(PropertyDataId::Setup)
-    }
-
-    pub fn default_script_id(&self) -> Option<Guid> {
-        self.get_data_prop(PropertyDataId::PhysicsScript)
-    }
-
-    pub fn default_script_intensity(&self) -> Option<f64> {
-        self.get_float_prop(PropertyFloat::PhysicsScriptIntensity)
-    }
-
-    pub fn house_owner_id(&self) -> Option<Guid> {
-        self.get_instance_prop(PropertyInstanceId::HouseOwner)
-    }
-
-    pub fn monarch_id(&self) -> Option<Guid> {
-        self.get_instance_prop(PropertyInstanceId::Monarch)
-    }
-
-    pub fn pet_owner_id(&self) -> Option<Guid> {
-        self.get_instance_prop(PropertyInstanceId::PetOwner)
-    }
-
-    pub fn icon_overlay_id(&self) -> Option<Guid> {
-        self.get_data_prop(PropertyDataId::IconOverlay)
-    }
-
-    pub fn icon_underlay_id(&self) -> Option<Guid> {
-        self.get_data_prop(PropertyDataId::IconUnderlay)
-    }
-
-    pub fn material_type(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::MaterialType)
-            .map(|v| v as u32)
-    }
-
-    pub fn hook_type(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::HookType).map(|v| v as u32)
-    }
-
-    pub fn hook_item_types(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::HookItemType)
-            .map(|v| v as u32)
-    }
-
-    pub fn hook_placement(&self) -> Option<u32> {
-        self.get_int_prop(PropertyInt::HookPlacement)
-            .map(|v| v as u32)
-    }
-
-    pub fn valid_locations(&self) -> EquipMask {
-        EquipMask::from_bits_truncate(
-            self.get_int_prop(PropertyInt::ValidLocations).unwrap_or(0) as u32
-        )
-    }
-
-    pub fn wield_location(&self) -> EquipMask {
-        EquipMask::from_bits_truncate(
-            self.get_int_prop(PropertyInt::CurrentWieldedLocation)
-                .unwrap_or(0) as u32,
-        )
-    }
-
-    pub fn attuned_status(&self) -> AttunedStatus {
-        match self.get_int_prop(PropertyInt::Attuned) {
-            Some(1) => AttunedStatus::Attuned,
-            Some(2) => AttunedStatus::Sticky,
-            _ => AttunedStatus::Normal,
-        }
-    }
-
-    pub fn is_stuck(&self) -> bool {
-        self.get_bool_prop(PropertyBool::Stuck)
-    }
-
-    pub fn is_locked(&self) -> bool {
-        self.get_bool_prop(PropertyBool::Locked)
-    }
-
-    pub fn is_attuned_sticky(&self) -> bool {
-        self.attuned_status() != AttunedStatus::Normal
     }
 
     pub fn apply_description(&mut self, data: &ObjectDescriptionData) {
@@ -359,32 +107,6 @@ impl Entity {
 
         // Hydrate properties from the description (using common mapping logic)
         self.properties.hydrate_from_odd(data);
-    }
-
-    pub fn is_sellable(&self) -> bool {
-        // IsSellable defaults to True in ACE if not specified
-        self.properties
-            .bools
-            .get(&PropertyBool::IsSellable)
-            .copied()
-            .unwrap_or(true)
-    }
-
-    pub fn is_tradable(&self) -> bool {
-        let attuned = self.attuned_status();
-        if attuned != AttunedStatus::Normal {
-            return false;
-        }
-
-        // Check for active pet
-        if self.get_int_prop(PropertyInt::PetClass).is_some()
-            && let Some(pet_guid) = self.get_instance_prop(PropertyInstanceId::Pet)
-            && !pet_guid.is_null()
-        {
-            return false;
-        }
-
-        true
     }
 
     pub fn new(guid: Guid, name: String, position: WorldPosition) -> Self {
@@ -436,19 +158,6 @@ impl Entity {
         }
     }
 
-    pub fn name(&self) -> &str {
-        self.get_string_prop(PropertyString::Name)
-            .unwrap_or("Unknown")
-    }
-
-    pub fn can_hold_items(&self) -> bool {
-        self.items_capacity().unwrap_or(0) > 0
-    }
-
-    pub fn has_active_pet(&self) -> bool {
-        self.get_instance_prop(PropertyInstanceId::Pet)
-            .is_some_and(|id| id != Guid::NULL)
-    }
 }
 
 pub struct EntityManager {

--- a/crates/holtburger-world/src/handlers/inventory.rs
+++ b/crates/holtburger-world/src/handlers/inventory.rs
@@ -3,6 +3,7 @@ use crate::entity::Entity;
 use crate::state::WorldState;
 use crate::state::liveness::EntityUpsertKind;
 use holtburger_common::Guid;
+use holtburger_common::properties::WorldObjectExt as _;
 use holtburger_common::properties::{
     PropertyInstanceId, PropertyUpdate, WorldObjectPropertyAccessorsMut,
 };

--- a/crates/holtburger-world/src/state/liveness.rs
+++ b/crates/holtburger-world/src/state/liveness.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use holtburger_common::Guid;
+use holtburger_common::properties::WorldObjectExt as _;
 
 use crate::StateEvent;
 use crate::entity::Entity;

--- a/crates/holtburger-world/src/state/mutations.rs
+++ b/crates/holtburger-world/src/state/mutations.rs
@@ -1,7 +1,7 @@
 use super::*;
 use holtburger_common::math::Quaternion;
 use holtburger_common::position::WorldPosition;
-use holtburger_common::properties::WorldObjectPropertyAccessors;
+use holtburger_common::properties::WorldObjectExt as _;
 
 impl WorldState {
     pub(crate) fn mark_entity_immediately_eligible_for_pruning_if_unretained(
@@ -27,11 +27,7 @@ impl WorldState {
             (
                 entity.container_id(),
                 entity.wielder_id(),
-                EquipMask::from_bits_truncate(
-                    entity
-                        .get_int_prop(PropertyInt::CurrentWieldedLocation)
-                        .unwrap_or(0) as u32,
-                ),
+                entity.wield_location(),
             )
         }) else {
             return;

--- a/crates/holtburger-world/src/state/tests.rs
+++ b/crates/holtburger-world/src/state/tests.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 use crate::state::liveness::EntityUpsertKind;
 
 use holtburger_common::position::WorldPosition;
+use holtburger_common::properties::WorldObjectExt as _;
 use holtburger_common::properties::WorldObjectProperties;
 
 #[test]

--- a/crates/holtburger-world/src/state/types.rs
+++ b/crates/holtburger-world/src/state/types.rs
@@ -2,7 +2,7 @@ use binrw::BinRead;
 use holtburger_common::Guid;
 use holtburger_common::properties::{
     EnchantmentTypeFlags, EquipMask, PropertyFloat, PropertyInt, WorldObjectPropertyAccessors,
-    WorldObjectPropertyAccessorsMut,
+    WorldObjectPropertyAccessorsMut, WorldObjectExt as _,
 };
 use holtburger_dat::ResourceProvider;
 use holtburger_dat::file_type::{SkillTable, SpellTable, XpTable};


### PR DESCRIPTION
This pull request refactors the `holtburger-cli` codebase to consistently use the `WorldObjectExt` trait for accessing entity and item properties. This change replaces direct property map access and older accessor traits with more expressive and type-safe methods, improving code readability and maintainability across the dashboard panels and utility functions.

**Trait usage and imports:**

- Replaces manual property lookups and the use of `WorldObjectPropertyAccessors` with the `WorldObjectExt` trait throughout the CLI code, updating imports and trait bounds accordingly. [[1]](diffhunk://#diff-d038459a24b6ffe543ed768787615a5534c1186e7a5886b66339b8cd5be8bf64R4) [[2]](diffhunk://#diff-907b01826157ba132523a78831a835b7b133e516d181ff9e0bc104e4fa33f3b6L1-R3) [[3]](diffhunk://#diff-2f37b234c5010ff3d85cf644672424a4b4d57dd7a2e10a3d7661865a21fb1816L7-R7) [[4]](diffhunk://#diff-22fd2536f809a98d570994953ae34d9171a128bc379156706807830d608813ceL2-R3) [[5]](diffhunk://#diff-4a2b4461a27c6a5dfc613b6ffca1e4d3a04f77433d6e0b7a9174170640e7adb6L12-R12) [[6]](diffhunk://#diff-a222bf96e411c33e39c5cc58fd37b6f609f9e670da8be1301a19e608044a0301L13-R13) [[7]](diffhunk://#diff-1ea041c26b1dd446cdc189265b987d94d7dda0a1c81d6dc8da5ab7d38fd4ba58L5-R5) [[8]](diffhunk://#diff-78fe6376304403a0fe1017efd90f67ef377d0124d9293abdd745be4d775b7a36L11-R11) [[9]](diffhunk://#diff-50ef9957a58e962463855fb2a715557b5281974da468875b7cc841491417e782L6-R6) [[10]](diffhunk://#diff-8b11fa4985aa46a6a3c2e03de91b031e7d91c50388f04bcc55eac1afd8b814acL14-R14) [[11]](diffhunk://#diff-a2457bcebc08beba5dba25ddf443d6c3abe09eb1ddad6eff1ab1c00df3550815R4) [[12]](diffhunk://#diff-eb8ecf5df42e1bf55e8461b84736f22b7882492f3b41a91c30fed9335a0f6ac3L4-R6) [[13]](diffhunk://#diff-c9d0782b44776513d6da1a92aef90ab7adbb4645f719d254f086d14a88583106R19) [[14]](diffhunk://#diff-663005938cf539371671a8a616464cfc8ab6d51fdfca77ca2756b1814115f9f6R8) [[15]](diffhunk://#diff-5084cee2d9500467bf15f309162c2a06f3b8af2a54b8107a4a1597e1455fb224L3-R8)

**Refactoring property access:**

- Updates code to use `WorldObjectExt` methods (e.g., `.name()`, `.item_value()`, `.item_type()`, `.stack_size()`, `.structure()`, `.max_structure()`, `.is_locked()`, `.burden()`) instead of direct property map access or previous helper methods, especially in display, debug, and classification logic. [[1]](diffhunk://#diff-907b01826157ba132523a78831a835b7b133e516d181ff9e0bc104e4fa33f3b6L39-R50) [[2]](diffhunk://#diff-2f37b234c5010ff3d85cf644672424a4b4d57dd7a2e10a3d7661865a21fb1816L42-R44) [[3]](diffhunk://#diff-22fd2536f809a98d570994953ae34d9171a128bc379156706807830d608813ceL111-R139) [[4]](diffhunk://#diff-22fd2536f809a98d570994953ae34d9171a128bc379156706807830d608813ceR254-R260) [[5]](diffhunk://#diff-78fe6376304403a0fe1017efd90f67ef377d0124d9293abdd745be4d775b7a36L83-R83) [[6]](diffhunk://#diff-5084cee2d9500467bf15f309162c2a06f3b8af2a54b8107a4a1597e1455fb224L19-R30)

**Entity/item classification improvements:**

- Refactors entity and item classification logic to use `WorldObjectExt`, enabling more robust and consistent determination of item types and flags for UI purposes. [[1]](diffhunk://#diff-22fd2536f809a98d570994953ae34d9171a128bc379156706807830d608813ceL111-R139) [[2]](diffhunk://#diff-22fd2536f809a98d570994953ae34d9171a128bc379156706807830d608813ceR254-R260)

**Utility function updates:**

- Refactors `format_item_name` and related utility functions to use `WorldObjectExt`, simplifying logic and improving display consistency for item names, stack sizes, and structure values. [[1]](diffhunk://#diff-5084cee2d9500467bf15f309162c2a06f3b8af2a54b8107a4a1597e1455fb224L3-R8) [[2]](diffhunk://#diff-5084cee2d9500467bf15f309162c2a06f3b8af2a54b8107a4a1597e1455fb224L19-R30)

**General codebase consistency:**

- Applies these changes across all relevant CLI dashboard panels and utility modules, ensuring a unified approach to property access and reducing code duplication. (All references above)