### PR TITLE
Chore/release builds scripting

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,12 +62,14 @@ jobs:
         shell: bash
         run: |
           mkdir -p staging/dats
+          mkdir -p staging/scripts
           EXT=""
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then EXT=".exe"; fi
           cp target/release/tui$EXT staging/holtburger-cli$EXT
           cp target/release/dat2hba$EXT staging/dat2hba$EXT
           cp target/release/dat-tool$EXT staging/dat-tool$EXT || true
           cp dats/assets.hba staging/dats/assets.hba
+          cp -R scripts/. staging/scripts/
           ARCHIVE_NAME="holtburger-nightly-${{ matrix.target }}"
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             7z a "$ARCHIVE_NAME.zip" ./staging/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Extra static files to include in distributions
-include = ["dats/README.md"]
+include = ["dats/README.md", "scripts"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ Nightly builds and archives for Windows, Mac, and Linux are available on the [Re
 holtburger-cli.exe --help
 ```
 
-Custom scripts can stored in `EXTRACT_DIR/scripts/` (must be writeable).
+Custom scripts can be stored in `EXTRACT_DIR/scripts/` (must be writeable).
 
 ### MacOS Install
 
-1. Download the macOS archive.
+1. Download the MacOS archive.
 2. Extract it.
 3. Launch the binary from the extracted folder:
 
@@ -119,7 +119,7 @@ Custom scripts can stored in `EXTRACT_DIR/scripts/` (must be writeable).
 ./holtburger-cli --help
 ```
 
-Custom scripts can stored in `EXTRACT_DIR/scripts/` (must be writeable).
+Custom scripts can be stored in `EXTRACT_DIR/scripts/` (must be writeable).
 
 ### Linux Flatpak (recommended)
 
@@ -141,7 +141,7 @@ By default the Flatpak bundle sets `SCRIPT_DIR` to the writable per-app data tre
 ./holtburger-cli --help
 ```
 
-Custom scripts can stored in `EXTRACT_DIR/scripts/` (must be writeable).
+Custom scripts can be stored in `EXTRACT_DIR/scripts/` (must be writeable).
 
 ### Source / Local Development
 
@@ -236,7 +236,7 @@ At runtime, the frontend constructs a `holtburger-content::ContentRepository` fr
 3.  Local `./dats/` directory relative to the binary.
 4.  Standard OS Data Directory:
     *   **Linux**: `~/.local/share/holtburger/dats/`
-    *   **macOS**: `~/Library/Application Support/io.github.merklejerk.holtburger/dats/`
+    *   **MacOS**: `~/Library/Application Support/io.github.merklejerk.holtburger/dats/`
     *   **Windows**: `%APPDATA%\merklejerk\holtburger\data\dats\`
 
 > **Note:** Official DAT files no longer need to be renamed when passed to tooling. Runtime startup no longer scans raw DAT files; use `dat2hba` to produce a namespaced `assets.hba` bundle first.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ There are three practical ways to get started:
 
 Nightly prebuilt archives are available on the [Releases](https://github.com/merklejerk/holtburger/releases) page. These archives already include the bundled namespaced `assets.hba` needed for the current TUI/runtime path, so this is the fastest way to get to a running client.
 
+They also ship the bundled `scripts/` directory alongside the executable so the scripting runtime has its default on-disk payload.
+
 1. Download the archive for your platform.
 2. Extract it.
 3. Launch the binary from the extracted folder:
@@ -125,6 +127,8 @@ flatpak run io.github.merklejerk.holtburger-cli --help
 ```
 
 The Flatpak ships with the same bundled namespaced `assets.hba`, so it is ready to run immediately.
+
+It also ships the packaged `scripts/` directory, seeds a writable `SCRIPT_DIR`, and keeps per-script config under `${SCRIPT_DIR}/.config`.
 
 ### From Source
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Holtburger is comprised of several specialized crates:
 - **[`holtburger-session`](crates/holtburger-session)**: The pure networking layer. Handles UDP fragment reassembly, packet sequencing, and stream encryption.
 - **[`holtburger-world`](crates/holtburger-world)**: The state authority. Tracks the live data graph of the 3D world, entity locations, and physics in memory.
 - **[`holtburger-core`](crates/holtburger-core)**: The primary engine orchestrator. Manages client state, translates network messages into authoritative states, and broadcasts UI-safe delta streams.
-- **[`holtburger-scripting`](crates/holtburger-scripting)**: The scripting runtime. Owns the Deno-based host, shared script boundary types, and the frontend-owned projection seam used by automation.
+- **[`holtburger-scripting`](crates/holtburger-scripting)**: The scripting runtime. Owns the Deno-based host, shared script boundary types, and the frontend-owned projection seam used by automation. See the [Scripting Guide](crates/holtburger-scripting/SCRIPTING_GUIDE.md) for a quickstart and API reference.
 - **[`holtburger-cli`](apps/holtburger-cli)**: A Terminal User Interface (TUI) client built on the Holtburger stack, designed for interaction, automation, and power users.
 - **[`holtburger-tools`](apps/holtburger-tools)**: A collection of auxiliary command-line utilities for data extraction and protocol analysis.
 
@@ -95,19 +95,23 @@ Holtburger is **highly experimental**. APIs are unstable and subject to frequent
 
 ## Installation and First Run
 
-There are three practical ways to get started:
+Nightly builds and archives for Windows, Mac, and Linux are available on the [Releases](https://github.com/merklejerk/holtburger/releases) page. All bundles ship with a minimal (`micro`) assets file, `assets.hba`, so they're ready to run immediately.
 
-- **Binary release**: best for most users on Windows, macOS, and Linux.
-- **Flatpak**: best for Linux users who want a packaged install.
-- **From source**: best if you are developing on Holtburger itself.
+### Windows Install
 
-### Binary Releases (Recommended)
+1. Download the Windows archive.
+2. Extract it.
+3. Launch the executable from the extracted folder:
 
-Nightly prebuilt archives are available on the [Releases](https://github.com/merklejerk/holtburger/releases) page. These archives already include the bundled namespaced `assets.hba` needed for the current TUI/runtime path, so this is the fastest way to get to a running client.
+```powershell
+holtburger-cli.exe --help
+```
 
-They also ship the bundled `scripts/` directory alongside the executable so the scripting runtime has its default on-disk payload.
+Custom scripts can stored in `EXTRACT_DIR/scripts/` (must be writeable).
 
-1. Download the archive for your platform.
+### MacOS Install
+
+1. Download the macOS archive.
 2. Extract it.
 3. Launch the binary from the extracted folder:
 
@@ -115,22 +119,31 @@ They also ship the bundled `scripts/` directory alongside the executable so the 
 ./holtburger-cli --help
 ```
 
-On Windows, run `holtburger-cli.exe --help` instead.
+Custom scripts can stored in `EXTRACT_DIR/scripts/` (must be writeable).
 
-### Flatpak (Linux)
+### Linux Flatpak (recommended)
 
-A nightly Flatpak bundle is also produced for Linux. Install it, then launch the app directly:
+Download the flatpak from releases then run `flatpak install ./holtburger-cli.flatpak`.
 
 ```bash
-flatpak install ./holtburger-cli.flatpak
 flatpak run io.github.merklejerk.holtburger-cli --help
 ```
 
-The Flatpak ships with the same bundled namespaced `assets.hba`, so it is ready to run immediately.
+By default the Flatpak bundle sets `SCRIPT_DIR` to the writable per-app data tree inside the sandbox (`/var/data/holtburger/scripts`, which Flatpak maps to `~/.var/app/$FLATPAK_ID/data/holtburger/scripts` on the host). You can store custom scripts there.
 
-It also ships the packaged `scripts/` directory, seeds a writable `SCRIPT_DIR`, and keeps per-script config under `${SCRIPT_DIR}/.config`.
+### Linux Tarball
 
-### From Source
+1. Download the Linux archive.
+2. Extract it.
+3. Launch the binary from the extracted folder:
+
+```bash
+./holtburger-cli --help
+```
+
+Custom scripts can stored in `EXTRACT_DIR/scripts/` (must be writeable).
+
+### Source / Local Development
 
 Building from source is mainly for local development.
 
@@ -148,7 +161,16 @@ For day-to-day development, run the TUI through Cargo:
 cargo run --bin tui -- --help
 ```
 
-Unlike the release archive and Flatpak, source builds do **not** bundle client data automatically. See [Data File Configuration](#data-file-configuration).
+The source tree uses `./scripts/` as the local script directory by default. Local scripts, script data, and per-script config live under that writable directory unless you override `SCRIPT_DIR`.
+
+Script storage:
+
+- Default local script directory: `./scripts/`
+- Custom scripts: `<SCRIPT_DIR>/<BASENAME>.js`
+- Script data: `<SCRIPT_DIR>/<BASENAME>.data.json`
+- Script config: `<SCRIPT_DIR>/.config/<BASENAME>.config.json`
+
+Unlike the release builds and Flatpak, source builds do **not** bundle client data automatically. See [Data File Configuration](#data-file-configuration).
 
 ## Running the TUI Client
 

--- a/TODO.md
+++ b/TODO.md
@@ -258,6 +258,7 @@
 - [x] `/version` and `--version`, seeded from commit hash env var set by build system?
 - [x] Attack spam too verbose.
 - [ ] `/promote <PLAYER>` - Promote new party leader.
+- [ ] Show "creature type" in assessment.
 
 ### Critical
 - [x] The individual fields in `Entity` are supposed to be stored in property maps!

--- a/apps/holtburger-cli/dist/io.github.merklejerk.holtburger-cli.yaml
+++ b/apps/holtburger-cli/dist/io.github.merklejerk.holtburger-cli.yaml
@@ -10,6 +10,8 @@ modules:
       # We build the binary outside the sandbox to avoid internet issues
       - install -D holtburger-cli /app/bin/holtburger-cli
       - install -D assets.hba /app/share/holtburger/dats/assets.hba
+      - install -d /app/share/holtburger/scripts
+      - cp -R scripts/. /app/share/holtburger/scripts/
       - install -D io.github.merklejerk.holtburger-cli.desktop /app/share/applications/io.github.merklejerk.holtburger-cli.desktop
       - install -D io.github.merklejerk.holtburger-cli.metainfo.xml /app/share/metainfo/io.github.merklejerk.holtburger-cli.metainfo.xml
       - install -D io.github.merklejerk.holtburger-cli.svg /app/share/icons/hicolor/scalable/apps/io.github.merklejerk.holtburger-cli.svg
@@ -18,6 +20,8 @@ modules:
         path: ../../../target/release/holtburger-cli
       - type: file
         path: ../../../dats/assets.hba
+      - type: dir
+        path: ../../../scripts
       - type: file
         path: io.github.merklejerk.holtburger-cli.desktop
       - type: file
@@ -27,3 +31,5 @@ modules:
 finish-args:
   - --share=network
   - --env=HOLTBURGER_DATS=/app/share/holtburger/dats
+  - --env=SCRIPT_DIR=/var/data/holtburger/scripts
+  - --env=SCRIPT_BUNDLE_DIR=/app/share/holtburger/scripts

--- a/apps/holtburger-cli/src/pages/game/combat.rs
+++ b/apps/holtburger-cli/src/pages/game/combat.rs
@@ -299,6 +299,12 @@ impl CombatEngagementState {
         self.pending_server_failure = None;
     }
 
+    pub fn recover_stalled_attack(&mut self) {
+        self.in_flight = false;
+        self.last_feedback = None;
+        self.pending_server_failure = None;
+    }
+
     pub fn handle_mode_updated(&mut self, mode: CombatMode) {
         match mode {
             CombatMode::Melee | CombatMode::Missile => {
@@ -395,6 +401,17 @@ impl CombatRuntimeState {
     pub fn clear_engagement(&mut self) {
         self.engagement.clear_engagement();
         self.issue_state = CombatIssueState::Idle;
+        self.last_attack_attempt_at = None;
+        self.pending_feedback_since = None;
+    }
+
+    pub fn recover_stalled_attack(&mut self) {
+        self.engagement.recover_stalled_attack();
+        self.issue_state = if self.engagement.desired().is_some() {
+            CombatIssueState::Ready
+        } else {
+            CombatIssueState::Idle
+        };
         self.last_attack_attempt_at = None;
         self.pending_feedback_since = None;
     }
@@ -727,6 +744,17 @@ fn clear_stale_combat_engagement(
         result.request_redraw(RedrawPriority::Immediate);
         return true;
     };
+
+    if should_rearm_sticky_auto_attack(state) {
+        log::warn!(
+            "combat engagement timed out waiting for feedback for target 0x{:08X}; recovering combat state",
+            target_guid.0
+        );
+        state.data.combat_runtime.recover_stalled_attack();
+        state.clear_combat_drive();
+        result.request_redraw(RedrawPriority::Immediate);
+        return true;
+    }
 
     log::warn!(
         "combat engagement timed out waiting for feedback for target 0x{:08X}; clearing combat state",
@@ -1581,7 +1609,7 @@ mod tests {
     }
 
     #[test]
-    fn silent_ready_attack_loop_times_out_and_clears_engagement() {
+    fn silent_ready_attack_loop_times_out_and_recovers_when_target_remains_available() {
         let player_guid = Guid(0x50000003);
         let target_guid = Guid(0x60000003);
         let mut state = GameState::new(player_guid, "Player".to_string(), "World".to_string());
@@ -1619,18 +1647,25 @@ mod tests {
             &mut result,
         );
 
-        assert_eq!(state.data.combat_runtime.desired_engagement(), None);
+        assert_eq!(
+            state.data.combat_runtime.desired_engagement(),
+            Some(DesiredCombatEngagement {
+                target_guid,
+                mode: CombatMode::Melee,
+            })
+        );
         assert_eq!(
             state.data.combat_runtime.issue_state,
-            CombatIssueState::Idle
+            CombatIssueState::Ready
         );
+        assert_eq!(state.data.combat_runtime.pending_feedback_since(), None);
         assert!(!result.commands.iter().any(|command| {
             matches!(command, ClientCommand::TargetedMeleeAttack { target, .. } if *target == target_guid)
         }));
     }
 
     #[test]
-    fn silent_in_flight_attack_times_out_and_clears_engagement() {
+    fn silent_in_flight_attack_times_out_and_clears_engagement_when_target_is_unavailable() {
         let player_guid = Guid(0x50000004);
         let target_guid = Guid(0x60000004);
         let mut state = GameState::new(player_guid, "Player".to_string(), "World".to_string());
@@ -1665,6 +1700,8 @@ mod tests {
             .combat_runtime
             .handle_feedback(&CombatFeedback::AttackCommenced);
         assert!(state.data.combat_runtime.pending_feedback_since().is_some());
+
+        state.data.entities.remove(&target_guid);
 
         let mut result = UpdateResult::new();
         let cleared = clear_stale_combat_engagement(

--- a/apps/holtburger-cli/src/pages/game/input/commands.rs
+++ b/apps/holtburger-cli/src/pages/game/input/commands.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::pages::game::data::CuratedCharacterOption;
-use crate::scripting::{DeferredScriptSource, discoverable_script_basenames};
+use crate::scripting::{
+    DeferredScriptSource, DiscoverableScriptSource, discoverable_scripts, script_directory,
+};
 use crate::types::{AppUiAction, ChatMessageTags, RedrawPriority};
 use holtburger_core::client::types::ChatChannelKind;
 use holtburger_world::context::WorldContextExt;
@@ -204,29 +206,47 @@ impl GameState {
 
         self.chat.log(
             ChatMessageTags::system(),
-            format!("Script status: {status}"),
+            format!(
+                "Current script: {} ({})",
+                current_source.unwrap_or_else(|| "none".to_string()),
+                status
+            ),
         );
         self.chat.log(
             ChatMessageTags::system(),
             format!(
-                "Current script: {}",
-                current_source.unwrap_or_else(|| "none".to_string())
+                "Local script dir: {}",
+                script_directory()
+                    .canonicalize()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|_| "?".to_string())
             ),
         );
 
-        match discoverable_script_basenames() {
-            Ok(basenames) if basenames.is_empty() => self.chat.log(
+        match discoverable_scripts() {
+            Ok(entries) if entries.is_empty() => self.chat.log(
                 ChatMessageTags::system(),
                 "Discovered scripts: none found.".to_string(),
             ),
-            Ok(basenames) => self.chat.log(
-                ChatMessageTags::system(),
-                format!(
-                    "Discovered scripts ({}): {}",
-                    basenames.len(),
-                    basenames.join(", ")
-                ),
-            ),
+            Ok(entries) => {
+                self.chat.log(
+                    ChatMessageTags::system(),
+                    format!("Discovered scripts ({}):", entries.len()),
+                );
+
+                for entry in entries {
+                    let system_suffix = if entry.source == DiscoverableScriptSource::System {
+                        " (SYSTEM)"
+                    } else {
+                        ""
+                    };
+
+                    self.chat.log(
+                        ChatMessageTags::system(),
+                        format!("- {}{}", entry.basename, system_suffix),
+                    );
+                }
+            }
             Err(error) => log::error!("Unable to list discovered scripts: {error:?}"),
         }
     }
@@ -429,7 +449,8 @@ impl GameState {
             ],
             "scripts" => vec![
                 "Usage: /scripts".to_string(),
-                "Show the current script status and discoverable script basenames.".to_string(),
+                "Show the current script status, local script dir, and discovered scripts."
+                    .to_string(),
                 "Use /run <BASENAME> to load SCRIPT_DIR/<BASENAME>.js and /unrun to stop it."
                     .to_string(),
             ],
@@ -1043,11 +1064,7 @@ mod tests {
         assert!(result.commands.is_empty());
         assert!(state.chat.messages.iter().any(|message| {
             message.chat_tags.contains(ChatMessageTags::system())
-                && message.text == "Script status: idle"
-        }));
-        assert!(state.chat.messages.iter().any(|message| {
-            message.chat_tags.contains(ChatMessageTags::system())
-                && message.text == "Current script: none"
+                && message.text == "Current script: none (idle)"
         }));
     }
 
@@ -1084,10 +1101,6 @@ mod tests {
     //     let result = state.handle_input(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 
     //     assert!(result.commands.is_empty());
-    //     assert!(state.chat.messages.iter().any(|message| {
-    //         message.chat_tags.contains(ChatMessageTags::system())
-    //             && message.text == "Script status: running"
-    //     }));
     //     assert!(state.chat.messages.iter().any(|message| {
     //         message.chat_tags.contains(ChatMessageTags::system())
     //             && message.text == "Current script: script-command-test"

--- a/apps/holtburger-cli/src/pages/game/input/commands.rs
+++ b/apps/holtburger-cli/src/pages/game/input/commands.rs
@@ -293,7 +293,7 @@ impl GameState {
         );
         self.chat.log(
             ChatMessageTags::system(),
-            "Scripting: /script <MSG> sends a message to the active script; /scripts shows running and discoverable scripts; /run <BASENAME> loads SCRIPT_DIR/<BASENAME>.js; /unrun stops the active script and clears queued startup".to_string(),
+            "Scripting: /script <MSG> sends a message to the active script; /scripts shows running and discoverable scripts; /run <BASENAME> loads <BASENAME>.js; /unrun stops the active script and clears queued startup".to_string(),
         );
         self.chat.log(
             ChatMessageTags::system(),
@@ -437,8 +437,6 @@ impl GameState {
             "run" => vec![
                 "Usage: /run <BASENAME>".to_string(),
                 "Load or replace the active long-running script for this session.".to_string(),
-                "The client loads SCRIPT_DIR/<BASENAME>.js, where SCRIPT_DIR defaults to scripts/."
-                    .to_string(),
                 "Example: /run loot-bot".to_string(),
             ],
             "script" => vec![

--- a/apps/holtburger-cli/src/scripting.rs
+++ b/apps/holtburger-cli/src/scripting.rs
@@ -949,16 +949,6 @@ fn script_bundle_directory() -> Option<PathBuf> {
     std::env::var_os(SCRIPT_BUNDLE_DIR_ENV_VAR)
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
-        .or_else(|| {
-            std::env::current_exe()
-                .ok()
-                .and_then(|path| path.parent().map(|dir| dir.join(DEFAULT_SCRIPT_DIR)))
-                .filter(|path| path.exists())
-        })
-        .or_else(|| {
-            let local_scripts = PathBuf::from("./").join(DEFAULT_SCRIPT_DIR);
-            local_scripts.exists().then_some(local_scripts)
-        })
 }
 
 fn resolve_script_source_path_for_basename_in_dirs(

--- a/apps/holtburger-cli/src/scripting.rs
+++ b/apps/holtburger-cli/src/scripting.rs
@@ -53,6 +53,18 @@ fn script_data_path_for_name(script_dir: &Path, script_name: &str) -> Option<Pat
     Some(script_dir.join(format!("{stem}.data.json")))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiscoverableScriptSource {
+    Local,
+    System,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiscoverableScript {
+    pub basename: String,
+    pub source: DiscoverableScriptSource,
+}
+
 fn load_json_file(path: &Path) -> Option<ScriptJsonValue> {
     let contents = match fs::read_to_string(path) {
         Ok(contents) => contents,
@@ -70,6 +82,10 @@ fn load_json_file(path: &Path) -> Option<ScriptJsonValue> {
             None
         }
     }
+}
+
+fn first_existing_path(paths: impl IntoIterator<Item = Option<PathBuf>>) -> Option<PathBuf> {
+    paths.into_iter().flatten().find(|path| path.exists())
 }
 
 fn write_json_file(path: &Path, contents: &str) -> bool {
@@ -481,7 +497,11 @@ impl ScriptClientView for TuiScriptClientView<'_> {
 
     fn load_data(&self) -> Option<ScriptJsonValue> {
         let script_name = self.script_name?;
-        let path = script_data_path_for_name(&script_directory(), script_name)?;
+        let path = resolve_script_data_path_for_name_in_dirs(
+            &script_directory(),
+            script_bundle_directory().as_deref(),
+            script_name,
+        )?;
         load_json_file(&path)
     }
 
@@ -918,7 +938,7 @@ pub(crate) fn resolve_deferred_script_source(
     }
 }
 
-fn script_directory() -> PathBuf {
+pub(crate) fn script_directory() -> PathBuf {
     std::env::var_os(SCRIPT_DIR_ENV_VAR)
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
@@ -929,48 +949,49 @@ fn script_bundle_directory() -> Option<PathBuf> {
     std::env::var_os(SCRIPT_BUNDLE_DIR_ENV_VAR)
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
+        .or_else(|| {
+            std::env::current_exe()
+                .ok()
+                .and_then(|path| path.parent().map(|dir| dir.join(DEFAULT_SCRIPT_DIR)))
+                .filter(|path| path.exists())
+        })
+        .or_else(|| {
+            let local_scripts = PathBuf::from("./").join(DEFAULT_SCRIPT_DIR);
+            local_scripts.exists().then_some(local_scripts)
+        })
 }
 
-fn copy_missing_script_tree(source_dir: &Path, destination_dir: &Path) -> Result<()> {
-    if !source_dir.exists() {
-        return Ok(());
+fn resolve_script_source_path_for_basename_in_dirs(
+    local_script_dir: &Path,
+    system_script_dir: Option<&Path>,
+    basename: &str,
+) -> Result<PathBuf> {
+    let local_script_path = script_path_for_basename_in_dir(local_script_dir, basename)?;
+    if local_script_path.exists() {
+        return Ok(local_script_path);
     }
 
-    fs::create_dir_all(destination_dir)?;
-
-    for entry in fs::read_dir(source_dir)? {
-        let entry = entry?;
-        let source_path = entry.path();
-        let destination_path = destination_dir.join(entry.file_name());
-        let file_type = entry.file_type()?;
-
-        if file_type.is_dir() {
-            copy_missing_script_tree(&source_path, &destination_path)?;
-            continue;
-        }
-
-        if file_type.is_file() && !destination_path.exists() {
-            if let Some(parent) = destination_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            fs::copy(&source_path, &destination_path)?;
+    if let Some(script_dir) = system_script_dir {
+        let system_script_path = script_path_for_basename_in_dir(script_dir, basename)?;
+        if system_script_path.exists() {
+            return Ok(system_script_path);
         }
     }
 
-    Ok(())
+    Err(anyhow::anyhow!(
+        "script {basename} was not found in the local or system scripts directories"
+    ))
 }
 
-fn seed_script_directory() -> Result<()> {
-    let Some(source_dir) = script_bundle_directory() else {
-        return Ok(());
-    };
-
-    let destination_dir = script_directory();
-    if source_dir == destination_dir {
-        return Ok(());
-    }
-
-    copy_missing_script_tree(&source_dir, &destination_dir)
+fn resolve_script_data_path_for_name_in_dirs(
+    local_script_dir: &Path,
+    system_script_dir: Option<&Path>,
+    script_name: &str,
+) -> Option<PathBuf> {
+    first_existing_path([
+        script_data_path_for_name(local_script_dir, script_name),
+        system_script_dir.and_then(|script_dir| script_data_path_for_name(script_dir, script_name)),
+    ])
 }
 
 fn validate_script_basename(basename: &str) -> Result<&str> {
@@ -999,9 +1020,11 @@ fn script_path_for_basename_in_dir(script_dir: &Path, basename: &str) -> Result<
 }
 
 pub(crate) fn deferred_script_source_for_basename(basename: &str) -> Result<DeferredScriptSource> {
-    seed_script_directory()?;
-    let script_dir = script_directory();
-    let path = script_path_for_basename_in_dir(&script_dir, basename)?;
+    let path = resolve_script_source_path_for_basename_in_dirs(
+        &script_directory(),
+        script_bundle_directory().as_deref(),
+        basename,
+    )?;
     Ok(DeferredScriptSource::Path(path))
 }
 
@@ -1041,9 +1064,34 @@ fn discoverable_script_basenames_in_dir(script_dir: &Path) -> Result<Vec<String>
     Ok(basenames)
 }
 
-pub(crate) fn discoverable_script_basenames() -> Result<Vec<String>> {
-    seed_script_directory()?;
-    discoverable_script_basenames_in_dir(&script_directory())
+fn discoverable_script_entries_in_dir(
+    script_dir: &Path,
+    source: DiscoverableScriptSource,
+) -> Result<Vec<DiscoverableScript>> {
+    Ok(discoverable_script_basenames_in_dir(script_dir)?
+        .into_iter()
+        .map(|basename| DiscoverableScript { basename, source })
+        .collect())
+}
+
+pub(crate) fn discoverable_scripts() -> Result<Vec<DiscoverableScript>> {
+    let mut entries = BTreeMap::new();
+
+    for entry in
+        discoverable_script_entries_in_dir(&script_directory(), DiscoverableScriptSource::Local)?
+    {
+        entries.insert(entry.basename.clone(), entry);
+    }
+
+    if let Some(script_dir) = script_bundle_directory() {
+        for entry in
+            discoverable_script_entries_in_dir(&script_dir, DiscoverableScriptSource::System)?
+        {
+            entries.entry(entry.basename.clone()).or_insert(entry);
+        }
+    }
+
+    Ok(entries.into_values().collect())
 }
 
 #[cfg(test)]
@@ -1142,6 +1190,50 @@ mod tests {
             script_data_path_for_name(script_dir, "fighter.js"),
             Some(PathBuf::from("/tmp/holtburger-scripts/fighter.data.json"))
         );
+    }
+
+    #[test]
+    fn script_resolution_prefers_local_roots_over_system_roots() {
+        let local_dir = std::env::temp_dir().join(format!(
+            "holtburger-local-script-resolution-{}",
+            std::process::id()
+        ));
+        let system_dir = std::env::temp_dir().join(format!(
+            "holtburger-system-script-resolution-{}",
+            std::process::id()
+        ));
+
+        if local_dir.exists() {
+            fs::remove_dir_all(&local_dir).expect("remove stale local test directory");
+        }
+        if system_dir.exists() {
+            fs::remove_dir_all(&system_dir).expect("remove stale system test directory");
+        }
+
+        fs::create_dir_all(&local_dir).expect("create local test directory");
+        fs::create_dir_all(&system_dir).expect("create system test directory");
+
+        File::create(local_dir.join("fighter.js")).expect("create local fighter.js");
+        File::create(local_dir.join("fighter.data.json")).expect("create local fighter.data.json");
+        File::create(system_dir.join("fighter.js")).expect("create system fighter.js");
+        File::create(system_dir.join("fighter.data.json"))
+            .expect("create system fighter.data.json");
+
+        let script_path = resolve_script_source_path_for_basename_in_dirs(
+            &local_dir,
+            Some(&system_dir),
+            "fighter",
+        )
+        .expect("script path should resolve");
+        let data_path =
+            resolve_script_data_path_for_name_in_dirs(&local_dir, Some(&system_dir), "fighter.js")
+                .expect("data path should resolve");
+
+        assert_eq!(script_path, local_dir.join("fighter.js"));
+        assert_eq!(data_path, local_dir.join("fighter.data.json"));
+
+        fs::remove_dir_all(&local_dir).expect("clean up local test directory");
+        fs::remove_dir_all(&system_dir).expect("clean up system test directory");
     }
 
     #[test]

--- a/apps/holtburger-cli/src/scripting.rs
+++ b/apps/holtburger-cli/src/scripting.rs
@@ -32,6 +32,7 @@ use crate::pages::game::{GameData, GameState, ViewState};
 use crate::types::{AppAction, AppNotification, ChatMessageTags, Interaction, LocalConfirmation};
 
 const SCRIPT_DIR_ENV_VAR: &str = "SCRIPT_DIR";
+const SCRIPT_BUNDLE_DIR_ENV_VAR: &str = "SCRIPT_BUNDLE_DIR";
 const DEFAULT_SCRIPT_DIR: &str = "scripts";
 
 fn running_script_stem(script_name: &str) -> Option<&str> {
@@ -924,6 +925,54 @@ fn script_directory() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(DEFAULT_SCRIPT_DIR))
 }
 
+fn script_bundle_directory() -> Option<PathBuf> {
+    std::env::var_os(SCRIPT_BUNDLE_DIR_ENV_VAR)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn copy_missing_script_tree(source_dir: &Path, destination_dir: &Path) -> Result<()> {
+    if !source_dir.exists() {
+        return Ok(());
+    }
+
+    fs::create_dir_all(destination_dir)?;
+
+    for entry in fs::read_dir(source_dir)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination_dir.join(entry.file_name());
+        let file_type = entry.file_type()?;
+
+        if file_type.is_dir() {
+            copy_missing_script_tree(&source_path, &destination_path)?;
+            continue;
+        }
+
+        if file_type.is_file() && !destination_path.exists() {
+            if let Some(parent) = destination_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(&source_path, &destination_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn seed_script_directory() -> Result<()> {
+    let Some(source_dir) = script_bundle_directory() else {
+        return Ok(());
+    };
+
+    let destination_dir = script_directory();
+    if source_dir == destination_dir {
+        return Ok(());
+    }
+
+    copy_missing_script_tree(&source_dir, &destination_dir)
+}
+
 fn validate_script_basename(basename: &str) -> Result<&str> {
     let basename = basename.trim();
     anyhow::ensure!(!basename.is_empty(), "script basename cannot be empty");
@@ -950,6 +999,7 @@ fn script_path_for_basename_in_dir(script_dir: &Path, basename: &str) -> Result<
 }
 
 pub(crate) fn deferred_script_source_for_basename(basename: &str) -> Result<DeferredScriptSource> {
+    seed_script_directory()?;
     let script_dir = script_directory();
     let path = script_path_for_basename_in_dir(&script_dir, basename)?;
     Ok(DeferredScriptSource::Path(path))
@@ -992,6 +1042,7 @@ fn discoverable_script_basenames_in_dir(script_dir: &Path) -> Result<Vec<String>
 }
 
 pub(crate) fn discoverable_script_basenames() -> Result<Vec<String>> {
+    seed_script_directory()?;
     discoverable_script_basenames_in_dir(&script_directory())
 }
 

--- a/crates/holtburger-scripting/SCRIPTING_GUIDE.md
+++ b/crates/holtburger-scripting/SCRIPTING_GUIDE.md
@@ -1,0 +1,289 @@
+# Holtburger Scripting Guide
+
+This guide is a quickstart and reference for script authors working against the `holtburger-scripting` crate and the TUI runtime that embeds it.
+
+The runtime is intentionally small and opinionated:
+
+- Scripts are plain JavaScript files loaded by basename.
+- The host exposes a frozen global object named `HB`, with `Holtburger` as an alias.
+- Scripts receive structured events and can emit typed intents back to the frontend.
+- Script-specific config is local-only; script data can be local or bundled.
+
+For platform-specific install guidance and the writable script directory defaults, see the root [README](../../README.md#installation-and-first-run).
+
+## Embedded Runtime Limits
+
+The scripting host is an embedded Deno Core runtime, NOT the full Deno CLI or a general-purpose Node environment. You will not have access to raw filesystem ops, networking, or node libraries. The exported `HB` API is all you get.
+
+Practical constraints to keep in mind:
+
+- The host loads one JavaScript source per script. It does not manage a module graph for you.
+- There is no first-class TypeScript execution path at runtime. TypeScript needs to be compiled before the script is run.
+- You cannot `import()` or `require()` dependencies. If you want external dependencies, bundle them into the final JavaScript file.
+- The host injects `HB`/`Holtburger` and structured events, but it does not provide a browser DOM or UI framework runtime.
+- Long synchronous work will block the script host. Keep heavy work out of the hot path.
+
+The safest assumption is that a Holtburger script should be a small, deterministic control loop that reacts to client state and emits a few focused actions.
+
+## Quickstart
+
+1. Put a script in your writable local script directory, using the basename you want to run.
+2. Run the TUI.
+3. Use `/run <BASENAME>` to start the script, or `/scripts` to inspect what the client can see.
+
+The simplest useful script is usually an event handler that logs a little state and then grows from there.
+
+```js
+const config = HB.loadConfig() ?? { enabled: true };
+
+HB.onEvent((event) => {
+  if (event.kind === "Lifecycle" && event.data.kind === "Started") {
+    HB.log("info", "hello from Holtburger");
+    return;
+  }
+
+  if (event.kind === "Lifecycle" && event.data.kind === "Tick") {
+    if (config.enabled === false) {
+      return;
+    }
+
+    const self = HB.selfEntity();
+    if (!self) {
+      return;
+    }
+
+    HB.debugLog(`${self.name}: ${self.health}/${self.healthMax}`);
+  }
+});
+```
+
+The repo includes a larger example in [scripts/fighter.js](../../scripts/fighter.js).
+
+## Script Layout
+
+The runtime resolves scripts by basename. If both the writable local directory and the bundled `scripts/` tree contain the same basename, the local script wins.
+
+Typical local layout:
+
+```text
+<SCRIPT_DIR>/
+  my-bot.js
+  my-bot.data.json
+  .config/
+    my-bot.config.json
+```
+
+The filenames mean:
+
+- `<BASENAME>.js` is the script entrypoint.
+- `<BASENAME>.data.json` is optional script data, usually checked in or bundled.
+- `.config/<BASENAME>.config.json` is script-local config and always lives in the writable local tree.
+
+## Runtime Model
+
+Scripts are executed in a fresh Deno-based runtime that the frontend owns. The runtime injects the `HB`/`Holtburger` global and then loads your script.
+
+The host then dispatches structured events to every handler registered with `HB.onEvent(handler)`.
+
+Two practical consequences matter when you write scripts:
+
+- Keep module-level state small and explicit. It lives only for the lifetime of the running script host.
+- Put persistent values in `HB.loadConfig()` / `HB.writeConfig()` or in `HB.loadData()` if the data is static and meant to ship with the script.
+
+## TypeScript Workflow
+
+TypeScript is a good fit for authoring, but the runtime expects JavaScript output. The usual workflow is:
+
+1. Write your source in TypeScript.
+2. Type-check it with `tsc`.
+3. Bundle or transpile the result into a single JavaScript file.
+4. Place the generated `.js` output in the writable script directory.
+
+Useful patterns:
+
+- Keep authoring sources in a separate tree from the generated runtime script.
+- Emit one bundled `.js` file per runnable script basename.
+- Generate source maps during development if your bundler supports them.
+- Keep the runtime-facing entrypoint small and let helper modules disappear into the bundle.
+
+There is an experimental Holtburger API typedef file at [holtburger.d.ts](holtburger.d.ts).
+
+## Bundler Suggestions
+
+Any bundler that can flatten a dependency graph into a single browser-style or IIFE-style JavaScript file works well.
+
+Practical options:
+
+- `esbuild` for fast local iteration and a tiny config surface.
+- `tsup` if you want a TypeScript-first wrapper around `esbuild`.
+- `rollup` if you want more control over output shape and plugin composition.
+- `vite` if you already use it elsewhere and just want a build step that emits a bundle.
+
+Suggested build rules:
+
+- Target plain JavaScript output that does not depend on runtime module loading.
+- Avoid package-manager-only assumptions in the shipped file.
+- Prefer a single output file per script basename so the CLI can load it directly.
+- Keep any script data tables separate from the generated code if the data is meant to be edited or shipped independently.
+
+Example `esbuild` command:
+
+```bash
+esbuild src/index.ts --bundle --platform=browser --format=iife --target=es2020 --outfile=dist/fighter.js
+```
+
+That kind of workflow maps well to Holtburger because the runtime wants one runnable `.js` file and does not need the rest of your source tree at launch time.
+
+## Events
+
+`HB.onEvent(handler)` registers a function that receives every structured event from the host. Handlers are called synchronously in registration order.
+
+The event payloads are plain JSON objects serialized from the Rust `ScriptEvent` enums. The exact field names come from the Rust types in [src/types.rs](src/types.rs), but the high-level kinds are:
+
+- `Lifecycle`
+- `ChatMessage`
+- `Workflow`
+- `Command`
+- `WeenieError`
+- `SelfVitalsChanged`
+- `EntityAppeared`
+- `EntityDisappeared`
+- `EntityUpdated`
+- `InventoryChanged`
+- `SpellbookChanged`
+- `PartyChanged`
+
+Lifecycle events are especially important:
+
+- `Started` fires when the host is ready.
+- `Stopped` fires when the script is shutting down.
+- `Tick` fires on the normal update cadence and carries `elapsed_seconds`.
+
+The most common pattern is to handle `Started` for one-time setup and `Tick` for repeatable decision making.
+
+## Reading State
+
+Use the read helpers to inspect the current client snapshot.
+
+### Core Snapshot Helpers
+
+- `HB.selfEntity()` returns the player's own snapshot, or `null` if the client is not ready.
+- `HB.characterSheet()` returns the current attributes, vitals, and skills snapshot, or `null` if the client is not ready.
+- `HB.currentInteraction()` returns the current interaction state, such as target, approach, follow, or attack, or `null` if none is active.
+- `HB.combatInfo()` returns the current combat mode and related combat state; if no client snapshot is available yet, it returns the default empty combat view.
+- `HB.currentTradeInfo()` returns the active trade state, including the trade partner and both item lists, or `null` if no trade is active.
+- `HB.party()` returns the current party snapshot, or `null` if the client is not in a party.
+- `HB.currentOpenContainer()` returns the guid of the currently open container, or `null`.
+- `HB.inventory()` returns container views for the current inventory, or an empty array if the client snapshot is not ready.
+- `HB.equipment()` returns a JavaScript `Map` keyed by snake_case equipment slot name, with values containing `equipMask` and `itemGuid`; if no snapshot is available, it returns an empty map.
+
+### World Queries
+
+- `HB.entity(guid)` returns a single entity snapshot, or `null` if the guid is not known in the current client snapshot.
+- `HB.entityExists(guid)` checks whether a guid is known to the current client snapshot; it returns `false` when the snapshot is unavailable.
+- `HB.nearbyEntities(maxDistance, classifications)` returns nearby entity snapshots, optionally limited by distance in meters and filtered by snake_case entity kinds such as `player`, `monster`, or `container`.
+- `HB.distance(from, to)` computes the distance in meters between positions or guids; if the snapshot is unavailable, it returns `0`.
+- `HB.headingTo(from, to)` computes the heading in radians from one position or guid to another; if the snapshot is unavailable, it returns `0`.
+
+### Character and Combat Helpers
+
+- `HB.enchantments()` returns the active enchantment list, where each entry contains a spell id and end time; if the snapshot is unavailable, it returns an empty array.
+- `HB.spellbook()` returns the player's spell ids, or an empty array if the snapshot is unavailable.
+- `HB.inSpellbook(spellId)` checks whether the given spell id is in the spellbook; it returns `false` when the snapshot is unavailable.
+
+### Property Accessors
+
+These helpers read low-level entity properties by guid and property id:
+
+- `HB.entityBoolProp(guid, prop)` returns a boolean property value, or `null` if the guid or property id is unknown.
+- `HB.entityIntProp(guid, prop)` returns an integer property value, or `null` if the guid or property id is unknown.
+- `HB.entityInt64Prop(guid, prop)` returns a 64-bit integer property value as a JSON number, or `null` if the guid or property id is unknown.
+- `HB.entityFloatProp(guid, prop)` returns a floating-point property value, or `null` if the guid or property id is unknown.
+- `HB.entityStringProp(guid, prop)` returns a string property value, or `null` if the guid or property id is unknown.
+- `HB.entityDataProp(guid, prop)` returns the referenced data guid, or `null` if the guid or property id is unknown.
+- `HB.entityInstanceProp(guid, prop)` returns the referenced instance guid, or `null` if the guid or property id is unknown.
+
+Use them when the higher-level snapshots do not expose the data you need yet.
+
+## Emitting Actions
+
+The write side of the API emits frontend intents or direct client actions.
+
+### Logging and Chat
+
+- `HB.log(level, message)` emits a script log. Accepted levels are `trace`, `debug`, `info`, `warn`, `warning`, and `error`; unknown values fall back to `info`.
+- `HB.debugLog(message)` sends a message to the frontend debug log.
+- `HB.say(message)` sends in-game chat text.
+- `HB.emote(message)` sends an emote message.
+
+### Client Interaction
+
+- `HB.targetEntity(guid)` requests that the client target the given entity.
+- `HB.approach(guid)` requests movement toward the given entity.
+- `HB.follow(guid)` requests following the given entity.
+- `HB.attack(guid)` requests attacking the given entity.
+- `HB.cancelInteraction()` cancels the current client interaction workflow.
+
+### Movement and Combat
+
+- `HB.snapHeading(heading)` requests an immediate heading snap in radians.
+- `HB.scoot(distanceMeters)` requests a short forward scoot by the given distance in meters.
+- `HB.castSpell(spellId, target)` queues a spell cast by id, optionally against a target guid; pass `null` to omit the target.
+- `HB.respondToConfirmation(accepted)` accepts or declines the currently open confirmation dialog.
+
+### Inventory and Containers
+
+- `HB.openContainer(guid)` requests opening the given container guid.
+- `HB.closeContainer(guid)` requests closing the given container guid.
+- `HB.moveItem(item, container)` moves an item into a container.
+- `HB.stackItems(source, destination, amount)` moves a stack amount from one item to another.
+- `HB.splitItem(item, container, amount)` splits the given amount into the destination container.
+- `HB.combine(source, dest)` combines the source item with the destination item.
+- `HB.useWith(source, dest)` is an alias for `HB.combine(source, dest)` and emits the same intent.
+- `HB.salvage(tool, items)` salvages the listed item guids using the given tool guid.
+- `HB.assess(target)` requests an assess action on the target guid.
+- `HB.drop(item)` drops the item.
+- `HB.pickup(item, container)` picks up the item from the given container, or from the world when `container` is `null`.
+- `HB.equip(guid, slot)` equips the item into the named slot. Slot names use snake_case values such as `head_wear`, `melee_weapon`, or `cloak`.
+- `HB.unequip(guid)` unequips the item with the given guid.
+
+### Trade
+
+- `HB.openTrade(guid)` requests opening a trade with the given entity guid.
+- `HB.addToTrade(item)` adds an item to the current trade offer.
+- `HB.acceptTrade()` accepts the current trade offer.
+- `HB.declineTrade()` declines the current trade offer.
+- `HB.resetTrade()` clears the current trade offer without leaving the trade session.
+- `HB.exitTrade()` leaves the trade session.
+
+## Persistence
+
+Script persistence is intentionally split into two different concerns.
+
+### Config
+
+- `HB.loadConfig()` reads the script-local config from `.config/<BASENAME>.config.json`, or returns `null` if no config exists yet.
+- `HB.writeConfig(contents)` writes a string or JSON-serializable value to the same file and returns a boolean success flag.
+
+Use config for user preferences, toggles, and state that should survive script reloads but stay local to the machine.
+
+### Data
+
+- `HB.loadData()` reads optional script data, checking the writable local script directory first and then the bundled script tree, or returns `null` if no data is available.
+
+Use data for shipped tables, lookup data, and other script-owned resources that should be versioned with the script but may be overridden locally.
+
+## Practical Conventions
+
+- Prefer one top-level `HB.onEvent(...)` registration per script unless you have a strong reason to split handlers.
+- Treat `Started` as initialization and `Tick` as the steady-state control loop.
+- Keep action emission idempotent when possible. The same tick can be revisited many times while the client state is stable.
+- Store durable state in config, not in globals.
+- Use `HB.loadData()` for data tables that should travel with the script.
+
+## Reference Source
+
+If you need the exact runtime contract, these are the source files to read next:
+
+- [src/host.rs](src/host.rs) for the JavaScript host and `HB` API surface
+- [src/types.rs](src/types.rs) for the serializable script event and intent types

--- a/crates/holtburger-scripting/holtburger.d.ts
+++ b/crates/holtburger-scripting/holtburger.d.ts
@@ -1,0 +1,722 @@
+type JsonPrimitive = string | number | boolean | null;
+interface JsonObject {
+  [key: string]: any;
+}
+interface JsonArray extends Array<any> {}
+type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+
+type Guid = number;
+
+type PropertyBool = number;
+type PropertyInt = number;
+type PropertyInt64 = number;
+type PropertyFloat = number;
+type PropertyString = number;
+type PropertyDataId = number;
+type PropertyInstanceId = number;
+
+type ScriptLogLevelInput = "trace" | "debug" | "info" | "warn" | "warning" | "error";
+type ScriptEntityKind =
+  | "player"
+  | "npc"
+  | "vendor"
+  | "monster"
+  | "weapon"
+  | "apparel"
+  | "container"
+  | "item"
+  | "consumable"
+  | "money"
+  | "key"
+  | "writable"
+  | "healing_kit"
+  | "mana_stone"
+  | "door"
+  | "portal"
+  | "life_stone"
+  | "chest"
+  | "wand"
+  | "tool"
+  | "static_object"
+  | "unknown";
+
+type ScriptEquipmentSlotKind =
+  | "head_wear"
+  | "chest_wear"
+  | "abdomen_wear"
+  | "upper_arm_wear"
+  | "lower_arm_wear"
+  | "hand_wear"
+  | "upper_leg_wear"
+  | "lower_leg_wear"
+  | "foot_wear"
+  | "chest_armor"
+  | "abdomen_armor"
+  | "upper_arm_armor"
+  | "lower_arm_armor"
+  | "upper_leg_armor"
+  | "lower_leg_armor"
+  | "neck_wear"
+  | "left_wrist"
+  | "right_wrist"
+  | "left_finger"
+  | "right_finger"
+  | "melee_weapon"
+  | "shield"
+  | "missile_weapon"
+  | "missile_ammo"
+  | "caster"
+  | "two_handed"
+  | "trinket_one"
+  | "cloak"
+  | "sigil_one"
+  | "sigil_two"
+  | "sigil_three";
+
+type ScriptBusyOperation =
+  | "none"
+  | "use"
+  | "use_with_target"
+  | "salvage"
+  | "spell_cast"
+  | "buy"
+  | "sell";
+
+type ScriptChatChannelKind =
+  | "Say"
+  | "Tell"
+  | "Emote"
+  | "Fellowship"
+  | "Allegiance"
+  | "Vassals"
+  | "Patron"
+  | "Monarch"
+  | "CoVassals"
+  | "General"
+  | "Trade"
+  | "Lfg"
+  | "Roleplay"
+  | "Society"
+  | "Olthoi"
+  | "System"
+  | "Unknown";
+
+type AttackHeight = "High" | "Medium" | "Low";
+
+type CombatMode = "Undef" | "NonCombat" | "Melee" | "Missile" | "Magic";
+
+type ConfirmationType =
+  | "Undefined"
+  | "SwearAllegiance"
+  | "AlterSkill"
+  | "AlterAttribute"
+  | "Fellowship"
+  | "CraftInteraction"
+  | "Augmentation"
+  | "YesNo";
+
+type AttributeType =
+  | "StrengthAttr"
+  | "EnduranceAttr"
+  | "QuicknessAttr"
+  | "CoordinationAttr"
+  | "FocusAttr"
+  | "SelfAttr";
+
+type VitalType = "Health" | "Stamina" | "Mana";
+
+type TrainingLevel = "Unusable" | "Untrained" | "Trained" | "Specialized";
+
+type SkillType =
+  | "Axe"
+  | "Bow"
+  | "Crossbow"
+  | "Dagger"
+  | "Mace"
+  | "MeleeDefense"
+  | "MissileDefense"
+  | "Sling"
+  | "Spear"
+  | "Staff"
+  | "Sword"
+  | "ThrownWeapon"
+  | "UnarmedCombat"
+  | "ArcaneLore"
+  | "MagicDefense"
+  | "ManaConversion"
+  | "Spellcraft"
+  | "ItemTinkering"
+  | "AssessPerson"
+  | "Deception"
+  | "Healing"
+  | "Jump"
+  | "Lockpick"
+  | "Run"
+  | "Awareness"
+  | "ArmsAndArmorRepair"
+  | "AssessCreature"
+  | "WeaponTinkering"
+  | "ArmorTinkering"
+  | "MagicItemTinkering"
+  | "CreatureEnchantment"
+  | "ItemEnchantment"
+  | "LifeMagic"
+  | "WarMagic"
+  | "Leadership"
+  | "Loyalty"
+  | "Fletching"
+  | "Alchemy"
+  | "Cooking"
+  | "Salvaging"
+  | "TwoHandedCombat"
+  | "Gearcraft"
+  | "VoidMagic"
+  | "HeavyWeapons"
+  | "LightWeapons"
+  | "FinesseWeapons"
+  | "MissileWeapons"
+  | "Shield"
+  | "DualWield"
+  | "Recklessness"
+  | "SneakAttack"
+  | "DirtyFighting"
+  | "Challenge"
+  | "Summoning";
+
+type WeenieError = string;
+
+type ScriptLocalConfirmationKind = "Unswear" | { Other: string };
+
+interface Vector3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+interface Quaternion {
+  w: number;
+  x: number;
+  y: number;
+  z: number;
+}
+
+// Matches the Rust field names exactly.
+interface WorldPosition {
+  landblock_id: Guid;
+  coords: Vector3;
+  rotation: Quaternion;
+}
+
+type ScriptPositionRef = Guid | WorldPosition;
+
+interface ScriptSelfView {
+  guid: Guid;
+  name: string;
+  position: WorldPosition;
+  health: number;
+  healthMax: number;
+  stamina: number;
+  staminaMax: number;
+  mana: number;
+  manaMax: number;
+  encumbrance: number;
+  capacity: number;
+  busyOperation: ScriptBusyOperation;
+  heading: number;
+  combatMode: CombatMode;
+}
+
+interface ScriptCharacterSheetView {
+  attributes: ScriptCharacterAttributeView[];
+  vitals: ScriptCharacterVitalView[];
+  skills: ScriptCharacterSkillView[];
+}
+
+interface ScriptCharacterAttributeView {
+  attributeType: AttributeType;
+  base: number;
+  effective: number;
+}
+
+interface ScriptCharacterVitalView {
+  vitalType: VitalType;
+  base: number;
+  effective: number;
+  current: number;
+}
+
+interface ScriptCharacterSkillView {
+  skillType: SkillType;
+  base: number;
+  effective: number;
+  training: TrainingLevel;
+}
+
+interface ScriptCombatInfo {
+  combatMode: CombatMode;
+  isEngaged: boolean;
+  target: Guid | null;
+  power: number;
+  height: AttackHeight;
+  lastAttackTime: number | null;
+}
+
+interface ScriptClientInteractionTargetEntity {
+  kind: "TargetEntity";
+  data: {
+    guid: Guid;
+  };
+}
+
+interface ScriptClientInteractionApproach {
+  kind: "Approach";
+  data: {
+    guid: Guid;
+  };
+}
+
+interface ScriptClientInteractionFollow {
+  kind: "Follow";
+  data: {
+    guid: Guid;
+  };
+}
+
+interface ScriptClientInteractionAttack {
+  kind: "Attack";
+  data: {
+    guid: Guid;
+  };
+}
+
+type ScriptClientInteraction =
+  | ScriptClientInteractionTargetEntity
+  | ScriptClientInteractionApproach
+  | ScriptClientInteractionFollow
+  | ScriptClientInteractionAttack;
+
+interface ScriptEnchantmentView {
+  spellId: number;
+  endTime: number;
+}
+
+interface ArmorProfile {
+  slashing: number;
+  piercing: number;
+  bludgeoning: number;
+  cold: number;
+  fire: number;
+  acid: number;
+  nether: number;
+  lightning: number;
+}
+
+interface CreatureAttributes {
+  strength: number;
+  endurance: number;
+  quickness: number;
+  coordination: number;
+  focus: number;
+  self_attr: number;
+  stamina: number;
+  mana: number;
+  stamina_max: number;
+  mana_max: number;
+}
+
+interface CreatureBuffs {
+  highlights: number;
+  colors: number;
+}
+
+interface CreatureProfile {
+  flags: number;
+  health: number;
+  health_max: number;
+  attributes: CreatureAttributes | null;
+  buffs: CreatureBuffs | null;
+}
+
+interface WeaponProfile {
+  damage_type: number;
+  weapon_time: number;
+  weapon_skill: number;
+  damage: number;
+  damage_variance: number;
+  damage_mod: number;
+  weapon_length: number;
+  max_velocity: number;
+  weapon_offense: number;
+  max_velocity_estimated: number;
+}
+
+interface ScriptEntityArmorProfile {
+  kind: "Armor";
+  data: ArmorProfile;
+}
+
+interface ScriptEntityCreatureProfile {
+  kind: "Creature";
+  data: CreatureProfile;
+}
+
+interface ScriptEntityWeaponProfile {
+  kind: "Weapon";
+  data: WeaponProfile;
+}
+
+// Serialized with the Rust enum variant names.
+type ScriptEntityProfile =
+  | ScriptEntityArmorProfile
+  | ScriptEntityCreatureProfile
+  | ScriptEntityWeaponProfile;
+
+interface ScriptMotionCommandNone {
+  kind: "none";
+}
+
+interface ScriptMotionCommandStop {
+  kind: "stop";
+}
+
+interface ScriptMotionCommandWalkForward {
+  kind: "walk_forward";
+}
+
+interface ScriptMotionCommandWalkBackwards {
+  kind: "walk_backwards";
+}
+
+interface ScriptMotionCommandRunForward {
+  kind: "run_forward";
+}
+
+interface ScriptMotionCommandTurnRight {
+  kind: "turn_right";
+}
+
+interface ScriptMotionCommandTurnLeft {
+  kind: "turn_left";
+}
+
+interface ScriptMotionCommandSidestepRight {
+  kind: "sidestep_right";
+}
+
+interface ScriptMotionCommandSidestepLeft {
+  kind: "sidestep_left";
+}
+
+interface ScriptMotionCommandDead {
+  kind: "dead";
+}
+
+interface ScriptMotionCommandOther {
+  kind: "other";
+  data: number;
+}
+
+type ScriptMotionCommand =
+  | ScriptMotionCommandNone
+  | ScriptMotionCommandStop
+  | ScriptMotionCommandWalkForward
+  | ScriptMotionCommandWalkBackwards
+  | ScriptMotionCommandRunForward
+  | ScriptMotionCommandTurnRight
+  | ScriptMotionCommandTurnLeft
+  | ScriptMotionCommandSidestepRight
+  | ScriptMotionCommandSidestepLeft
+  | ScriptMotionCommandDead
+  | ScriptMotionCommandOther;
+
+interface ScriptEntityView {
+  guid: Guid;
+  name: string | null;
+  kind: ScriptEntityKind;
+  position: WorldPosition;
+  profile: ScriptEntityProfile | null;
+  container: Guid;
+  wielder: Guid;
+  distanceToSelf: number;
+  motionCommand: ScriptMotionCommand;
+}
+
+interface ScriptContainerView {
+  containerGuid: Guid;
+  slots: number;
+  items: Guid[];
+}
+
+interface ScriptEquipmentSlotState {
+  equipMask: number;
+  itemGuid: Guid | null;
+}
+
+interface ScriptTradeInfo {
+  partnerGuid: Guid;
+  partnerName: string | null;
+  ourItems: Guid[];
+  theirItems: Guid[];
+}
+
+interface ScriptPartyMemberView {
+  guid: Guid;
+  name: string | null;
+  healthPercent: number | null;
+  staminaPercent: number | null;
+  manaPercent: number | null;
+}
+
+interface ScriptPartyView {
+  leaderGuid: Guid;
+  members: ScriptPartyMemberView[];
+}
+
+interface ScriptSpellEffectView {
+  spellId: number;
+  name: string | null;
+  remainingSeconds: number | null;
+  targetGuid: Guid | null;
+}
+
+interface ScriptChatEvent {
+  channel: ScriptChatChannelKind;
+  sender: string | null;
+  message: string;
+}
+
+interface ActiveCharacterConfirmation {
+  confirmation_type: ConfirmationType;
+  context: number;
+  text: string;
+}
+
+interface ScriptCharacterConfirmation {
+  kind: "Character";
+  data: ActiveCharacterConfirmation;
+}
+
+interface ScriptLocalConfirmation {
+  kind: ScriptLocalConfirmationKind;
+  text: string;
+}
+
+interface ScriptLocalConfirmationWrapper {
+  kind: "Local";
+  data: ScriptLocalConfirmation;
+}
+
+type ScriptConfirmation = ScriptCharacterConfirmation | ScriptLocalConfirmationWrapper;
+
+interface ScriptLifecycleStartedEvent {
+  kind: "Started";
+}
+
+interface ScriptLifecycleStoppedEvent {
+  kind: "Stopped";
+}
+
+interface ScriptLifecycleTickEvent {
+  kind: "Tick";
+  data: {
+    elapsed_seconds: number;
+  };
+}
+
+type ScriptLifecycleEvent =
+  | ScriptLifecycleStartedEvent
+  | ScriptLifecycleStoppedEvent
+  | ScriptLifecycleTickEvent;
+
+interface ScriptWorkflowConfirmationOpenedEvent {
+  kind: "ConfirmationOpened";
+  data: {
+    confirmation: ScriptConfirmation;
+  };
+}
+
+interface ScriptWorkflowConfirmationClosedEvent {
+  kind: "ConfirmationClosed";
+}
+
+interface ScriptWorkflowBusyOperationChangedEvent {
+  kind: "BusyOperationChanged";
+  data: {
+    busy: ScriptBusyOperation;
+  };
+}
+
+interface ScriptWorkflowTargetEntityChangedEvent {
+  kind: "TargetEntityChanged";
+  data: {
+    guid: Guid | null;
+  };
+}
+
+type ScriptWorkflowEvent =
+  | ScriptWorkflowConfirmationOpenedEvent
+  | ScriptWorkflowConfirmationClosedEvent
+  | ScriptWorkflowBusyOperationChangedEvent
+  | ScriptWorkflowTargetEntityChangedEvent;
+
+interface ScriptChatMessageEvent {
+  kind: "ChatMessage";
+  data: ScriptChatEvent;
+}
+
+interface ScriptEventLifecycle {
+  kind: "Lifecycle";
+  data: ScriptLifecycleEvent;
+}
+
+interface ScriptEventWorkflow {
+  kind: "Workflow";
+  data: ScriptWorkflowEvent;
+}
+
+interface ScriptEventCommand {
+  kind: "Command";
+  data: {
+    msg: string;
+  };
+}
+
+interface ScriptEventWeenieError {
+  kind: "WeenieError";
+  data: {
+    error: WeenieError;
+  };
+}
+
+interface ScriptEventSelfVitalsChanged {
+  kind: "SelfVitalsChanged";
+}
+
+interface ScriptEventEntityAppeared {
+  kind: "EntityAppeared";
+  data: {
+    guid: Guid;
+  };
+}
+
+interface ScriptEventEntityDisappeared {
+  kind: "EntityDisappeared";
+  data: {
+    guid: Guid;
+  };
+}
+
+interface ScriptEventEntityUpdated {
+  kind: "EntityUpdated";
+  data: {
+    guid: Guid;
+  };
+}
+
+interface ScriptEventInventoryChanged {
+  kind: "InventoryChanged";
+  data: {
+    added: Guid[];
+    removed: Guid[];
+  };
+}
+
+interface ScriptEventSpellbookChanged {
+  kind: "SpellbookChanged";
+}
+
+interface ScriptEventPartyChanged {
+  kind: "PartyChanged";
+}
+
+type ScriptEvent =
+  | ScriptChatMessageEvent
+  | ScriptEventLifecycle
+  | ScriptEventWorkflow
+  | ScriptEventCommand
+  | ScriptEventWeenieError
+  | ScriptEventSelfVitalsChanged
+  | ScriptEventEntityAppeared
+  | ScriptEventEntityDisappeared
+  | ScriptEventEntityUpdated
+  | ScriptEventInventoryChanged
+  | ScriptEventSpellbookChanged
+  | ScriptEventPartyChanged;
+
+type ScriptEventHandler = (event: ScriptEvent) => void;
+
+interface HoltburgerApi {
+  onEvent(handler: ScriptEventHandler): void;
+
+  selfEntity(): ScriptSelfView | null;
+  characterSheet(): ScriptCharacterSheetView | null;
+  currentInteraction(): ScriptClientInteraction | null;
+  combatInfo(): ScriptCombatInfo;
+  currentTradeInfo(): ScriptTradeInfo | null;
+  party(): ScriptPartyView | null;
+  currentOpenContainer(): Guid | null;
+  inventory(): ScriptContainerView[];
+  equipment(): Map<ScriptEquipmentSlotKind, ScriptEquipmentSlotState>;
+
+  entity(guid: Guid): ScriptEntityView | null;
+  entityExists(guid: Guid): boolean;
+  nearbyEntities(maxDistance?: number | null, classifications?: ScriptEntityKind[] | null): ScriptEntityView[];
+  distance(from: ScriptPositionRef, to: ScriptPositionRef): number;
+  headingTo(from: ScriptPositionRef, to: ScriptPositionRef): number;
+
+  enchantments(): ScriptEnchantmentView[];
+  spellbook(): number[];
+  inSpellbook(spellId: number): boolean;
+
+  entityBoolProp(guid: Guid, prop: PropertyBool): boolean | null;
+  entityIntProp(guid: Guid, prop: PropertyInt): number | null;
+  entityInt64Prop(guid: Guid, prop: PropertyInt64): number | null;
+  entityFloatProp(guid: Guid, prop: PropertyFloat): number | null;
+  entityStringProp(guid: Guid, prop: PropertyString): string | null;
+  entityDataProp(guid: Guid, prop: PropertyDataId): Guid | null;
+  entityInstanceProp(guid: Guid, prop: PropertyInstanceId): Guid | null;
+
+  loadConfig(): JsonValue | null;
+  loadData(): JsonValue | null;
+  writeConfig(contents: string | JsonValue): boolean;
+
+  log(level: string, message: string): void;
+  debugLog(message: string): void;
+  say(message: string): void;
+  emote(message: string): void;
+
+  targetEntity(guid: Guid): void;
+  approach(guid: Guid): void;
+  follow(guid: Guid): void;
+  attack(guid: Guid): void;
+  cancelInteraction(): void;
+
+  snapHeading(heading: number): void;
+  scoot(distanceMeters: number): void;
+  castSpell(spellId: number, target?: Guid | null): void;
+  respondToConfirmation(accepted: boolean): void;
+
+  openContainer(guid: Guid): void;
+  closeContainer(guid: Guid): void;
+  moveItem(item: Guid, container: Guid): void;
+  stackItems(source: Guid, destination: Guid, amount: number): void;
+  splitItem(item: Guid, container: Guid, amount: number): void;
+  combine(source: Guid, dest: Guid): void;
+  useWith(source: Guid, dest: Guid): void;
+  salvage(tool: Guid, items: Guid[]): void;
+  assess(target: Guid): void;
+  drop(item: Guid): void;
+  pickup(item: Guid, container?: Guid | null): void;
+  equip(guid: Guid, slot: ScriptEquipmentSlotKind): void;
+  unequip(guid: Guid): void;
+
+  openTrade(guid: Guid): void;
+  addToTrade(item: Guid): void;
+  acceptTrade(): void;
+  declineTrade(): void;
+  resetTrade(): void;
+  exitTrade(): void;
+}
+
+declare const HB: HoltburgerApi;
+declare const Holtburger: HoltburgerApi;


### PR DESCRIPTION
This pull request enhances script management in the `holtburger-cli` app by introducing support for bundled/system scripts alongside local scripts, improving script discovery and resolution, and updating documentation and packaging accordingly. The changes provide a clearer user experience for script handling, especially in release builds, and ensure that script data and scripts are resolved correctly from local or bundled sources.

**Script system enhancements:**

* Added support for a system/bundled script directory (`SCRIPT_BUNDLE_DIR`), allowing the CLI to discover and resolve scripts from both local (`scripts/`) and bundled/system locations, with local scripts taking precedence if duplicates exist. This affects script loading, data resolution, and discovery commands. [[1]](diffhunk://#diff-257ae4695a794bc60ffcac8b5957eea8c8d09684fdc417b53e5de567966c3b3fR35) [[2]](diffhunk://#diff-257ae4695a794bc60ffcac8b5957eea8c8d09684fdc417b53e5de567966c3b3fL920-R996) [[3]](diffhunk://#diff-257ae4695a794bc60ffcac8b5957eea8c8d09684fdc417b53e5de567966c3b3fL953-R1027) [[4]](diffhunk://#diff-257ae4695a794bc60ffcac8b5957eea8c8d09684fdc417b53e5de567966c3b3fL994-R1094) [[5]](diffhunk://#diff-4f546243097fb1c40d4b0585dcd2110029e5f04044258a7c31ba13f990418a73L3-R5) [[6]](diffhunk://#diff-4f546243097fb1c40d4b0585dcd2110029e5f04044258a7c31ba13f990418a73L207-R249)
* Introduced new types (`DiscoverableScript`, `DiscoverableScriptSource`) and refactored script discovery logic to show both local and system scripts in the `/scripts` command, with clear labeling in the UI. [[1]](diffhunk://#diff-257ae4695a794bc60ffcac8b5957eea8c8d09684fdc417b53e5de567966c3b3fR56-R67) [[2]](diffhunk://#diff-4f546243097fb1c40d4b0585dcd2110029e5f04044258a7c31ba13f990418a73L207-R249) [[3]](diffhunk://#diff-4f546243097fb1c40d4b0585dcd2110029e5f04044258a7c31ba13f990418a73L432-R453)
* Updated script data resolution logic so that script data files are also found in either the local or system directory, preferring local if present. [[1]](diffhunk://#diff-257ae4695a794bc60ffcac8b5957eea8c8d09684fdc417b53e5de567966c3b3fL483-R504) [[2]](diffhunk://#diff-257ae4695a794bc60ffcac8b5957eea8c8d09684fdc417b53e5de567966c3b3fL920-R996)

**Testing improvements:**

* Added a test to ensure that local scripts and their data are preferred over system/bundled scripts when both exist.
* Updated existing tests and help messages to reflect the new script discovery and status output. [[1]](diffhunk://#diff-4f546243097fb1c40d4b0585dcd2110029e5f04044258a7c31ba13f990418a73L1046-R1067) [[2]](diffhunk://#diff-4f546243097fb1c40d4b0585dcd2110029e5f04044258a7c31ba13f990418a73L432-R453)

**Packaging and documentation updates:**

* Bundled the `scripts/` directory in release archives and Flatpak builds, updated the nightly workflow to include scripts, and clarified installation and script storage instructions in the `README.md`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L73-R73) [[2]](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6R65-R72) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L98-R146) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L147-R173)

These changes collectively make script management more robust and user-friendly, especially for users running from prebuilt releases or Flatpak packages.