### PR TITLE
Chore/harden 1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -86,9 +86,11 @@
 - [x] `/options` syntax is awkward.
 - [x] Rendering issues in chat for some names/items like the Blackmoor's Favor gem.
 - [x] Spellcasting chat should be categorized as combat.
+- [x] Excessive entity.clone()s - health and book updates replace entire entity.
 - [ ] All verbs should have equivalent slash chat commands.
 - [ ] Missing many unit tests for protocol types (lost in the refactor?).
 - [ ] PlayerState and entities mirroring in `WorldState` is annoying.
+    - [ ] Keep non-entity stuff in PlayerState and store an entity GUID there instead?
 - [ ] Implement actual collisions.
 - [ ] Use sibling files for tests.
 - [ ] Exit combat when trying to craft? Combine action that isn't unlocking with a key?

--- a/TODO.md
+++ b/TODO.md
@@ -87,6 +87,7 @@
 - [x] Rendering issues in chat for some names/items like the Blackmoor's Favor gem.
 - [x] Spellcasting chat should be categorized as combat.
 - [x] Excessive entity.clone()s - health and book updates replace entire entity.
+- [x] player kill messages rendering with `{0}` template.
 - [ ] All verbs should have equivalent slash chat commands.
 - [ ] Missing many unit tests for protocol types (lost in the refactor?).
 - [ ] PlayerState and entities mirroring in `WorldState` is annoying.

--- a/apps/holtburger-cli/src/pages/game/domains/chat.rs
+++ b/apps/holtburger-cli/src/pages/game/domains/chat.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::utils::format_action_result_message;
 use holtburger_core::ActionResultReason;
+use holtburger_core::client::types::CombatFeedback;
 use holtburger_core::errors::is_actually_weenie_error;
 
 pub(super) fn reduce_action(_state: &mut GameState, action: AppAction) -> UpdateResult {
@@ -11,9 +12,26 @@ pub(super) fn reduce_action(_state: &mut GameState, action: AppAction) -> Update
 }
 
 pub(super) fn reduce_view_event(state: &mut GameState, event: &ClientViewEvent) -> UpdateResult {
-    state
-        .chat
-        .handle_event(event, state.data.character_name.as_deref());
+    match event {
+        ClientViewEvent::CombatFeedback(CombatFeedback::PlayerKilled {
+            death_message,
+            victim_id,
+            killer_id,
+        }) => {
+            let message = resolve_player_killed_message(
+                &state.data,
+                death_message,
+                *victim_id,
+                *killer_id,
+            );
+            state.chat.log(ChatMessageTags::info().combat(), message);
+        }
+        _ => {
+            state
+                .chat
+                .handle_event(event, state.data.character_name.as_deref());
+        }
+    }
 
     match event {
         ClientViewEvent::ActionResult { reason, .. } => {
@@ -36,12 +54,45 @@ pub(super) fn reduce_view_event(state: &mut GameState, event: &ClientViewEvent) 
     }
 }
 
+fn resolve_player_killed_message(
+    data: &GameData,
+    death_message: &str,
+    victim_id: Guid,
+    killer_id: Guid,
+) -> String {
+    let mut resolved_message = death_message.to_string();
+
+    if let Some(victim_name) = data
+        .entities
+        .get(&victim_id)
+        .map(|entity| entity.name().trim())
+        .filter(|name| !name.is_empty())
+        && resolved_message.contains("{0}")
+    {
+        resolved_message = resolved_message.replace("{0}", victim_name);
+    }
+
+    if let Some(killer_name) = data
+        .entities
+        .get(&killer_id)
+        .map(|entity| entity.name().trim())
+        .filter(|name| !name.is_empty())
+        && resolved_message.contains("{1}")
+    {
+        resolved_message = resolved_message.replace("{1}", killer_name);
+    }
+
+    resolved_message
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use holtburger_common::Guid;
+    use holtburger_common::position::WorldPosition;
     use holtburger_core::client::types::ClientCommand;
     use holtburger_protocol::errors::WeenieError;
+    use holtburger_world::entity::Entity;
 
     #[test]
     fn emote_action_dispatches_emote_command() {
@@ -77,5 +128,35 @@ mod tests {
             AppAction::Log { chat_tags, message }
                 if *chat_tags == ChatMessageTags::error() && message == "You don't have all the components."
         ));
+    }
+
+    #[test]
+    fn nearby_player_killed_feedback_replaces_template_placeholder_with_victim_name() {
+        let player_guid = Guid(0x50000001);
+        let victim_guid = Guid(0x60000001);
+        let mut state = GameState::new(player_guid, "Player".to_string(), "World".to_string());
+
+        state.data.entities.insert(
+            victim_guid,
+            Entity::new(
+                victim_guid,
+                "Bestie".to_string(),
+                WorldPosition::default(),
+            ),
+        );
+
+        let _ = reduce_view_event(
+            &mut state,
+            &ClientViewEvent::CombatFeedback(CombatFeedback::PlayerKilled {
+                death_message: "{0} died!".to_string(),
+                victim_id: victim_guid,
+                killer_id: Guid(0x90AB_CDEF),
+            }),
+        );
+
+        let message = state.chat.messages.last().expect("death message should log");
+
+        assert!(message.chat_tags.contains(ChatMessageTags::COMBAT));
+        assert_eq!(message.text, "Bestie died!");
     }
 }

--- a/apps/holtburger-cli/src/pages/game/domains/entity.rs
+++ b/apps/holtburger-cli/src/pages/game/domains/entity.rs
@@ -31,6 +31,12 @@ pub(super) fn reduce_view_event(
                 result.request_redraw(RedrawPriority::Immediate);
             }
             inventory::refresh_entity_context_if_visible(state, entity_ref.guid, &mut result);
+            if matches!(
+                state.view.active_interaction,
+                Some(Interaction::Targeting { target_guid }) if target_guid == entity_ref.guid
+            ) {
+                result.commands.push(ClientCommand::QueryHealth(entity_ref.guid));
+            }
             inventory::sync_weapon_swap_controller(state, now, &mut result);
             if !was_ready && state.player_entity_is_ready() {
                 result.actions.push(AppAction::Notification {
@@ -150,7 +156,8 @@ pub(super) fn reduce_view_event(
 mod tests {
     use super::GameState;
     use super::reduce_view_event;
-    use crate::types::{AppAction, AppNotification};
+    use crate::types::{AppAction, AppNotification, Interaction};
+    use holtburger_core::ClientCommand;
     use holtburger_common::Guid;
     use holtburger_common::position::WorldPosition;
     use holtburger_core::ClientViewEvent;
@@ -181,5 +188,53 @@ mod tests {
             }] if *guid == player_guid
         ));
         assert!(state.data.entities.contains_key(&player_guid));
+    }
+
+    #[test]
+    fn entity_spawn_requeries_target_health_when_target_is_active() {
+        let player_guid = Guid(0x5000_0004);
+        let target_guid = Guid(0x6000_0001);
+        let mut state = GameState::new(player_guid, "Player".to_string(), "World".to_string());
+        state.view.active_interaction = Some(Interaction::Targeting { target_guid });
+
+        let result = reduce_view_event(
+            &mut state,
+            &ClientViewEvent::EntitySpawned {
+                entity: Box::new(Entity::new(
+                    target_guid,
+                    "Drudge".to_string(),
+                    WorldPosition::default(),
+                )),
+            },
+            Instant::now(),
+        );
+
+        assert!(result.commands.iter().any(|command| {
+            matches!(command, ClientCommand::QueryHealth(guid) if *guid == target_guid)
+        }));
+    }
+
+    #[test]
+    fn entity_replaced_requeries_target_health_when_target_is_active() {
+        let player_guid = Guid(0x5000_0004);
+        let target_guid = Guid(0x6000_0001);
+        let mut state = GameState::new(player_guid, "Player".to_string(), "World".to_string());
+        state.view.active_interaction = Some(Interaction::Targeting { target_guid });
+
+        let result = reduce_view_event(
+            &mut state,
+            &ClientViewEvent::EntityReplaced {
+                entity: Box::new(Entity::new(
+                    target_guid,
+                    "Drudge".to_string(),
+                    WorldPosition::default(),
+                )),
+            },
+            Instant::now(),
+        );
+
+        assert!(result.commands.iter().any(|command| {
+            matches!(command, ClientCommand::QueryHealth(guid) if *guid == target_guid)
+        }));
     }
 }

--- a/apps/holtburger-cli/src/pages/game/domains/entity.rs
+++ b/apps/holtburger-cli/src/pages/game/domains/entity.rs
@@ -40,6 +40,23 @@ pub(super) fn reduce_view_event(
                 });
             }
         }
+        ClientViewEvent::EntityHealthUpdated {
+            guid,
+            health_fraction,
+        } => {
+            if let Some(entity) = state.data.entities.get_mut(guid) {
+                entity.health_fraction = Some(*health_fraction);
+            }
+            inventory::refresh_entity_context_if_visible(state, *guid, &mut result);
+            result.request_redraw(RedrawPriority::Immediate);
+        }
+        ClientViewEvent::EntityBookUpdated { guid, book } => {
+            if let Some(entity) = state.data.entities.get_mut(guid) {
+                entity.book = Some(book.as_ref().clone());
+            }
+            inventory::refresh_entity_context_if_visible(state, *guid, &mut result);
+            result.request_redraw(RedrawPriority::Immediate);
+        }
         ClientViewEvent::EntityPropertiesUpdated { guid, updates } => {
             let mut needs_update = false;
             if let Some(entity) = state.data.entities.get_mut(guid) {

--- a/apps/holtburger-cli/src/pages/game/domains/tests/entity.rs
+++ b/apps/holtburger-cli/src/pages/game/domains/tests/entity.rs
@@ -37,6 +37,37 @@ fn test_entity_replaced_updates_cached_entity_state() {
 }
 
 #[test]
+fn health_update_event_updates_cached_entity_state() {
+    let player_guid = Guid(0x50000001);
+    let entity_guid = Guid(0x60000001);
+    let mut state = GameState::new(player_guid, "Player".to_string(), "World".to_string());
+
+    state.data.entities.insert(
+        entity_guid,
+        Entity::new(
+            entity_guid,
+            "Drudge".to_string(),
+            WorldPosition::default(),
+        ),
+    );
+
+    let result = state.handle_view_event(ClientViewEvent::EntityHealthUpdated {
+        guid: entity_guid,
+        health_fraction: 0.25,
+    });
+
+    assert!(result.redraw_requested());
+    assert_eq!(
+        state
+            .data
+            .entities
+            .get(&entity_guid)
+            .and_then(|entity| entity.health_fraction),
+        Some(0.25)
+    );
+}
+
+#[test]
 fn book_response_refreshes_visible_context_and_requests_redraw() {
     let player_guid = Guid(0x50000001);
     let book_guid = Guid(0x60000001);
@@ -70,8 +101,9 @@ fn book_response_refreshes_visible_context_and_requests_redraw() {
         ..BookData::default()
     });
 
-    let result = state.handle_view_event(ClientViewEvent::EntityReplaced {
-        entity: Box::new(book_entity),
+    let result = state.handle_view_event(ClientViewEvent::EntityBookUpdated {
+        guid: book_guid,
+        book: Box::new(book_entity.book.take().expect("book payload should exist")),
     });
 
     assert!(result.redraw_requested());

--- a/apps/holtburger-cli/src/scripting.rs
+++ b/apps/holtburger-cli/src/scripting.rs
@@ -979,7 +979,9 @@ pub(crate) fn script_event_from_view_event(event: &ClientViewEvent) -> Option<Sc
         ClientViewEvent::EntityIdentified { entity } => {
             Some(ScriptEvent::EntityUpdated { guid: entity.guid })
         }
-        ClientViewEvent::EntityPropertiesUpdated { guid, .. }
+        ClientViewEvent::EntityHealthUpdated { guid, .. }
+        | ClientViewEvent::EntityBookUpdated { guid, .. }
+        | ClientViewEvent::EntityPropertiesUpdated { guid, .. }
         | ClientViewEvent::EntityMoved { guid, .. }
         | ClientViewEvent::EntityKinematicsUpdated { guid, .. }
         | ClientViewEvent::EntityMotionUpdated { guid, .. }

--- a/crates/holtburger-core/src/client/mod.rs
+++ b/crates/holtburger-core/src/client/mod.rs
@@ -547,6 +547,25 @@ impl ClientRuntime {
                     self.emit_self_movement_kinematics_updated();
                 }
             }
+            WorldEvent::EntityHealthUpdated {
+                guid,
+                health_fraction,
+            } => {
+                let _ = self
+                    .client_view_event_tx
+                    .send(ClientViewEvent::EntityHealthUpdated {
+                        guid: *guid,
+                        health_fraction: *health_fraction,
+                    });
+            }
+            WorldEvent::EntityBookUpdated { guid, book } => {
+                let _ = self
+                    .client_view_event_tx
+                    .send(ClientViewEvent::EntityBookUpdated {
+                        guid: *guid,
+                        book: book.clone(),
+                    });
+            }
             WorldEvent::EntityIdentified(entity) => {
                 let _ = self
                     .client_view_event_tx

--- a/crates/holtburger-core/src/client/types.rs
+++ b/crates/holtburger-core/src/client/types.rs
@@ -19,6 +19,7 @@ use holtburger_protocol::messages::{
 };
 use holtburger_world::FellowshipActivity;
 use holtburger_world::SelfMovementKinematics;
+use holtburger_world::book::BookData;
 use holtburger_world::entity::{Entity, EntityMotionSnapshot};
 use holtburger_world::state::{FellowshipState, TradeState};
 use holtburger_world::stats::{
@@ -368,6 +369,14 @@ pub enum ClientViewEvent {
     },
     EntityReplaced {
         entity: Box<Entity>,
+    },
+    EntityHealthUpdated {
+        guid: Guid,
+        health_fraction: f32,
+    },
+    EntityBookUpdated {
+        guid: Guid,
+        book: Box<BookData>,
     },
     EntityIdentified {
         entity: Box<Entity>,

--- a/crates/holtburger-world/src/events.rs
+++ b/crates/holtburger-world/src/events.rs
@@ -1,3 +1,4 @@
+use crate::book::BookData;
 use crate::entity::{Entity, EntityMotionSnapshot};
 use crate::spatial::{RuntimeBodyResetCause, SpatialBodyId};
 use crate::state;
@@ -54,6 +55,14 @@ pub enum FellowshipActivity {
 pub enum WorldEvent {
     EntitySpawned(Box<Entity>),
     EntityReplaced(Box<Entity>),
+    EntityHealthUpdated {
+        guid: Guid,
+        health_fraction: f32,
+    },
+    EntityBookUpdated {
+        guid: Guid,
+        book: Box<BookData>,
+    },
     EntityMoved {
         guid: Guid,
         pos: WorldPosition,

--- a/crates/holtburger-world/src/handlers/inventory.rs
+++ b/crates/holtburger-world/src/handlers/inventory.rs
@@ -184,8 +184,12 @@ pub(crate) fn handle_event(
         GameEvent::BookDataResponse(data) => {
             let guid = data.object_guid;
             if let Some(entity) = state.entities.get_mut(guid) {
-                entity.book = Some(BookData::from_response(data));
-                events.push(WorldEvent::EntityReplaced(Box::new(entity.clone())));
+                let book = BookData::from_response(data);
+                entity.book = Some(book.clone());
+                events.push(WorldEvent::EntityBookUpdated {
+                    guid,
+                    book: Box::new(book),
+                });
                 true
             } else {
                 false
@@ -198,7 +202,12 @@ pub(crate) fn handle_event(
                     .book
                     .get_or_insert_with(BookData::default)
                     .apply_page_response(data);
-                events.push(WorldEvent::EntityReplaced(Box::new(entity.clone())));
+                if let Some(book) = entity.book.clone() {
+                    events.push(WorldEvent::EntityBookUpdated {
+                        guid,
+                        book: Box::new(book),
+                    });
+                }
                 true
             } else {
                 false

--- a/crates/holtburger-world/src/player/tests.rs
+++ b/crates/holtburger-world/src/player/tests.rs
@@ -688,8 +688,10 @@ fn test_update_motion_caches_remote_entity_motion_snapshot_and_emits_event() {
     )));
     assert!(events.iter().any(|event| matches!(
         event,
-        WorldEvent::EntityReplaced(entity)
-            if entity.guid == guid && entity.health_fraction == Some(0.0)
+        WorldEvent::EntityHealthUpdated {
+            guid: event_guid,
+            health_fraction,
+        } if *event_guid == guid && *health_fraction == 0.0
     )));
 }
 

--- a/crates/holtburger-world/src/state/mutations.rs
+++ b/crates/holtburger-world/src/state/mutations.rs
@@ -800,17 +800,15 @@ impl WorldState {
             }
         }
 
-        let mut replaced_entity = None;
         if let Some(entity) = self.entities.get_mut(guid)
             && entity.health_fraction != Some(health_fraction)
         {
             entity.health_fraction = Some(health_fraction);
-            replaced_entity = Some(entity.clone());
+            events.push(WorldEvent::EntityHealthUpdated {
+                guid,
+                health_fraction,
+            });
             updated = true;
-        }
-
-        if let Some(entity) = replaced_entity {
-            events.push(WorldEvent::EntityReplaced(Box::new(entity)));
         }
 
         updated

--- a/crates/holtburger-world/src/state/tests.rs
+++ b/crates/holtburger-world/src/state/tests.rs
@@ -1581,8 +1581,10 @@ fn test_update_health_updates_target_entity_fraction_and_emits_replace() {
     );
     assert!(events.iter().any(|event| matches!(
         event,
-        WorldEvent::EntityReplaced(entity)
-            if entity.guid == guid && entity.health_fraction == Some(0.5)
+        WorldEvent::EntityHealthUpdated {
+            guid: event_guid,
+            health_fraction,
+        } if *event_guid == guid && *health_fraction == 0.5
     )));
 }
 
@@ -4043,9 +4045,13 @@ fn test_book_data_response_updates_entity_book_state() {
 
     let events = state.handle_message(&message);
 
-    assert!(
-        matches!(events.first(), Some(WorldEvent::EntityReplaced(entity)) if entity.guid == guid)
-    );
+    assert!(matches!(
+        events.first(),
+        Some(WorldEvent::EntityBookUpdated {
+            guid: event_guid,
+            book,
+        }) if *event_guid == guid && book.inscription.as_deref() == Some("Signed and sealed")
+    ));
 
     let entity = state.entities.get(guid).expect("entity should still exist");
     let book = entity.book.as_ref().expect("book data should be populated");
@@ -4095,9 +4101,13 @@ fn test_book_page_data_response_merges_into_existing_book_state() {
 
     let events = state.handle_message(&message);
 
-    assert!(
-        matches!(events.first(), Some(WorldEvent::EntityReplaced(entity)) if entity.guid == guid)
-    );
+    assert!(matches!(
+        events.first(),
+        Some(WorldEvent::EntityBookUpdated {
+            guid: event_guid,
+            book,
+        }) if *event_guid == guid && book.pages.len() == 2
+    ));
 
     let entity = state.entities.get(guid).expect("entity should still exist");
     let book = entity.book.as_ref().expect("book data should be populated");


### PR DESCRIPTION
This pull request refactors how entity health and book updates are handled throughout the codebase. Instead of replacing the entire entity when just health or book data changes, new targeted events are emitted and handled, which improves efficiency and reduces unnecessary cloning. The changes also address a chat rendering bug with player kill messages and improve test coverage for these scenarios.

**Entity update event refactoring:**

* Introduced `EntityHealthUpdated` and `EntityBookUpdated` events in `WorldEvent` and `ClientViewEvent`, replacing previous patterns where the entire entity was replaced for health or book updates. [[1]](diffhunk://#diff-cb248aa418f5ab651cb4681430299cc7860952103050d6d9c7dbb03d56ffe29aR1) [[2]](diffhunk://#diff-cb248aa418f5ab651cb4681430299cc7860952103050d6d9c7dbb03d56ffe29aR58-R65) [[3]](diffhunk://#diff-0797cb9b6cf5fafe49028b663e78d9e13558d2bc78570c9b31af200f071dce54R373-R380)
* Updated the world and client logic to emit and handle these new events, updating only the relevant fields in the cached entity state. [[1]](diffhunk://#diff-26b20df57c69e4c8bd86d035f44dec33f5431e2e93339f7411cfc13bdfdb3248L803-L815) [[2]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR550-R568) [[3]](diffhunk://#diff-a7d8dbc188d98d08f4f269853a975545f0193d8fafafb73f286720deeb8dd3cbR49-R65)
* Refactored inventory and scripting handlers to use the new events instead of full entity replacement. [[1]](diffhunk://#diff-492ddd88725a56988836f1409dd412e783ae7e0196931171e2ca1acd97da32bbL187-R192) [[2]](diffhunk://#diff-492ddd88725a56988836f1409dd412e783ae7e0196931171e2ca1acd97da32bbL201-R210) [[3]](diffhunk://#diff-257ae4695a794bc60ffcac8b5957eea8c8d09684fdc417b53e5de567966c3b3fL982-R984)

**Bug fixes and chat improvements:**

* Fixed player kill messages in chat to properly resolve `{0}` and `{1}` placeholders with victim and killer names, and added tests to verify correct rendering. [[1]](diffhunk://#diff-2caf446ea59f532c0ad08489c4839c9a9eabab32a133765128d197d2727ebe35R15-R34) [[2]](diffhunk://#diff-2caf446ea59f532c0ad08489c4839c9a9eabab32a133765128d197d2727ebe35R57-R95) [[3]](diffhunk://#diff-2caf446ea59f532c0ad08489c4839c9a9eabab32a133765128d197d2727ebe35R132-R161)

**Testing and validation:**

* Added and updated tests to ensure that health and book updates only modify the relevant parts of the entity, and that the correct events are emitted and handled. [[1]](diffhunk://#diff-7a1c79e7436522393d8fc65f963b5fd813b527c6f14dc53b6ddb3fc9bb9502dcR39-R69) [[2]](diffhunk://#diff-7a1c79e7436522393d8fc65f963b5fd813b527c6f14dc53b6ddb3fc9bb9502dcL73-R106) [[3]](diffhunk://#diff-e1445f5dd92eb93b6f517dd3cd56db58d535e5888d15941c92c893796cab3873L1584-R1587) [[4]](diffhunk://#diff-e1445f5dd92eb93b6f517dd3cd56db58d535e5888d15941c92c893796cab3873L4046-R4054) [[5]](diffhunk://#diff-81e7f939a5bfb10b4751baad8b95931691f1a18d8b19cad41f0a19dcea6d4909L691-R694) [[6]](diffhunk://#diff-a7d8dbc188d98d08f4f269853a975545f0193d8fafafb73f286720deeb8dd3cbL136-R160) [[7]](diffhunk://#diff-a7d8dbc188d98d08f4f269853a975545f0193d8fafafb73f286720deeb8dd3cbR192-R239)

**Miscellaneous:**

* Updated the `TODO.md` to reflect the reduction in unnecessary `entity.clone()` operations and the fix for player kill message templates.
* Updated the ACE submodule reference.