### PR TITLE
Chore/player state refactor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -90,12 +90,12 @@
 - [x] player kill messages rendering with `{0}` template.
 - [x] PlayerState and entities mirroring in `WorldState` is annoying.
     - [x] Keep non-entity stuff in PlayerState and store an entity GUID there instead?
+- [x] Server messages being colored as errors, even though they aren't all errors.
 - [~] All verbs should have equivalent slash chat commands.
 - [ ] Missing many unit tests for protocol types (lost in the refactor?).
 - [ ] Implement actual collisions.
 - [ ] Use sibling files for tests.
 - [ ] Exit combat when trying to craft? Combine action that isn't unlocking with a key?
-- [ ] Server messages being colored as errors, even though they aren't all errors.
 - [ ] Some echantments duplicated in char tab.
 - [ ] `get_verbs() -> get_entities(self.selected_index)` pattern in tabs is inefficient because `get_entities()` is not cheap. We should store `selected_guid` when we update `selected_index` for tabs with entity content.
 - [ ] `holtburger-core` abuses the shit out of WireEvents.

--- a/TODO.md
+++ b/TODO.md
@@ -88,22 +88,22 @@
 - [x] Spellcasting chat should be categorized as combat.
 - [x] Excessive entity.clone()s - health and book updates replace entire entity.
 - [x] player kill messages rendering with `{0}` template.
-- [ ] All verbs should have equivalent slash chat commands.
+- [x] PlayerState and entities mirroring in `WorldState` is annoying.
+    - [x] Keep non-entity stuff in PlayerState and store an entity GUID there instead?
+- [~] All verbs should have equivalent slash chat commands.
 - [ ] Missing many unit tests for protocol types (lost in the refactor?).
-- [ ] PlayerState and entities mirroring in `WorldState` is annoying.
-    - [ ] Keep non-entity stuff in PlayerState and store an entity GUID there instead?
 - [ ] Implement actual collisions.
 - [ ] Use sibling files for tests.
 - [ ] Exit combat when trying to craft? Combine action that isn't unlocking with a key?
 - [ ] Server messages being colored as errors, even though they aren't all errors.
 - [ ] Some echantments duplicated in char tab.
-- [ ] Add intelligent entity context scanners.
 - [ ] `get_verbs() -> get_entities(self.selected_index)` pattern in tabs is inefficient because `get_entities()` is not cheap. We should store `selected_guid` when we update `selected_index` for tabs with entity content.
 - [ ] `holtburger-core` abuses the shit out of WireEvents.
 - [ ] should really prefix server vs client messages. There are some messages that are bi-directional and confusing.
 - [ ] Emotes.
 - [ ] Some equipment swapping jank going on.
-- [ ] Should untarget missing/too far entities and unsubscribe health query.
+- [ ] Get rid of noclip (dead code).
+- [ ] Speed up TUI rendering.
 
 ### High
 - [x] Fail when spell/attack distance is too far.

--- a/apps/holtburger-cli/src/pages/game/domains/chat.rs
+++ b/apps/holtburger-cli/src/pages/game/domains/chat.rs
@@ -18,12 +18,8 @@ pub(super) fn reduce_view_event(state: &mut GameState, event: &ClientViewEvent) 
             victim_id,
             killer_id,
         }) => {
-            let message = resolve_player_killed_message(
-                &state.data,
-                death_message,
-                *victim_id,
-                *killer_id,
-            );
+            let message =
+                resolve_player_killed_message(&state.data, death_message, *victim_id, *killer_id);
             state.chat.log(ChatMessageTags::info().combat(), message);
         }
         _ => {
@@ -138,11 +134,7 @@ mod tests {
 
         state.data.entities.insert(
             victim_guid,
-            Entity::new(
-                victim_guid,
-                "Bestie".to_string(),
-                WorldPosition::default(),
-            ),
+            Entity::new(victim_guid, "Bestie".to_string(), WorldPosition::default()),
         );
 
         let _ = reduce_view_event(
@@ -154,7 +146,11 @@ mod tests {
             }),
         );
 
-        let message = state.chat.messages.last().expect("death message should log");
+        let message = state
+            .chat
+            .messages
+            .last()
+            .expect("death message should log");
 
         assert!(message.chat_tags.contains(ChatMessageTags::COMBAT));
         assert_eq!(message.text, "Bestie died!");

--- a/apps/holtburger-cli/src/pages/game/domains/entity.rs
+++ b/apps/holtburger-cli/src/pages/game/domains/entity.rs
@@ -35,7 +35,9 @@ pub(super) fn reduce_view_event(
                 state.view.active_interaction,
                 Some(Interaction::Targeting { target_guid }) if target_guid == entity_ref.guid
             ) {
-                result.commands.push(ClientCommand::QueryHealth(entity_ref.guid));
+                result
+                    .commands
+                    .push(ClientCommand::QueryHealth(entity_ref.guid));
             }
             inventory::sync_weapon_swap_controller(state, now, &mut result);
             if !was_ready && state.player_entity_is_ready() {
@@ -157,9 +159,9 @@ mod tests {
     use super::GameState;
     use super::reduce_view_event;
     use crate::types::{AppAction, AppNotification, Interaction};
-    use holtburger_core::ClientCommand;
     use holtburger_common::Guid;
     use holtburger_common::position::WorldPosition;
+    use holtburger_core::ClientCommand;
     use holtburger_core::ClientViewEvent;
     use holtburger_world::entity::Entity;
     use std::time::Instant;

--- a/apps/holtburger-cli/src/pages/game/domains/tests/entity.rs
+++ b/apps/holtburger-cli/src/pages/game/domains/tests/entity.rs
@@ -44,11 +44,7 @@ fn health_update_event_updates_cached_entity_state() {
 
     state.data.entities.insert(
         entity_guid,
-        Entity::new(
-            entity_guid,
-            "Drudge".to_string(),
-            WorldPosition::default(),
-        ),
+        Entity::new(entity_guid, "Drudge".to_string(), WorldPosition::default()),
     );
 
     let result = state.handle_view_event(ClientViewEvent::EntityHealthUpdated {

--- a/crates/holtburger-core/src/client/commands.rs
+++ b/crates/holtburger-core/src/client/commands.rs
@@ -1710,15 +1710,13 @@ mod tests {
         let mut client = builder::build_test_client(ClientState::Connected);
         let mut events = client.subscribe_client_view_events();
         let player_guid = Guid(0x5000_0001);
-
-        client.world.player.guid = player_guid;
-        client.world.player.position = WorldPosition {
+        let player_pose = WorldPosition {
             landblock_id: Guid(0x0102_0000),
             ..WorldPosition::default()
         };
-        client
-            .world
-            .set_local_player_runtime_pose(client.world.player.position);
+
+        client.world.player.guid = player_guid;
+        client.world.set_local_player_runtime_pose(player_pose);
         client.character_selection.characters = vec![CharacterEntry {
             guid: player_guid,
             name: "Player".to_string(),

--- a/crates/holtburger-core/src/client/messages.rs
+++ b/crates/holtburger-core/src/client/messages.rs
@@ -1067,6 +1067,7 @@ mod tests {
         )));
 
         let mut saw_options_projection = false;
+        let mut saw_authoritative_player_spawn = false;
         while let Ok(event) = events.try_recv() {
             if matches!(
                 event,
@@ -1075,11 +1076,20 @@ mod tests {
                         && options.options2 == CharacterOptions2::SHOW_HELM
             ) {
                 saw_options_projection = true;
-                break;
+            }
+
+            if matches!(
+                event,
+                ClientViewEvent::EntitySpawned { entity }
+                    if entity.guid == holtburger_common::Guid(0x50000001)
+                        && entity.name() == "Test Player"
+            ) {
+                saw_authoritative_player_spawn = true;
             }
         }
 
         assert!(saw_options_projection);
+        assert!(saw_authoritative_player_spawn);
     }
 
     #[tokio::test]

--- a/crates/holtburger-core/src/client/messages.rs
+++ b/crates/holtburger-core/src/client/messages.rs
@@ -1047,10 +1047,11 @@ mod tests {
 
         client.handle_world_event(&WorldEvent::PlayerInfo(Box::new(
             holtburger_world::PlayerInfoData {
-                guid: holtburger_common::Guid(0x50000001),
-                name: "Test Player".to_string(),
-                pos: None,
-                player_entity: None,
+                entity: Box::new(Entity::new(
+                    holtburger_common::Guid(0x50000001),
+                    "Test Player".to_string(),
+                    WorldPosition::default(),
+                )),
                 attributes: Vec::new(),
                 vitals: Vec::new(),
                 skills: Vec::new(),

--- a/crates/holtburger-core/src/client/messages.rs
+++ b/crates/holtburger-core/src/client/messages.rs
@@ -681,14 +681,9 @@ mod tests {
         };
         client.world.player.guid = player_guid;
         client.world.player.server_control_sequence = 9;
-        client.world.player.position = position;
         client
             .world
-            .add_entity(holtburger_world::entity::Entity::new(
-                player_guid,
-                "Player".to_string(),
-                position,
-            ));
+            .seed_local_player_entity(player_guid, "Player", position);
 
         let encoded = encode_message(&server_controlled_motion(player_guid, 10, 20));
 
@@ -723,14 +718,9 @@ mod tests {
         let player_guid = holtburger_common::Guid(0x50000001);
         client.world.player.guid = player_guid;
         client.world.player.server_control_sequence = 10;
-        client.world.player.position = WorldPosition::default();
         client
             .world
-            .add_entity(holtburger_world::entity::Entity::new(
-                player_guid,
-                "Player".to_string(),
-                WorldPosition::default(),
-            ));
+            .seed_local_player_entity(player_guid, "Player", WorldPosition::default());
 
         let encoded = encode_message(&server_controlled_motion(player_guid, 9, 19));
 
@@ -757,12 +747,10 @@ mod tests {
         };
 
         client.world.player.guid = player_guid;
-        client.world.player.position = start;
         client.world.player.server_control_sequence = 9;
         client
             .world
-            .entities
-            .insert(Entity::new(player_guid, "Player".to_string(), start));
+            .seed_local_player_entity(player_guid, "Player", start);
 
         let encoded = encode_message(&server_controlled_move_to_position(
             player_guid,
@@ -775,7 +763,7 @@ mod tests {
         client.handle_message(&encoded).await.unwrap();
 
         assert_eq!(client.world.player.server_control_sequence, 10);
-        assert_eq!(client.world.player.position, start);
+        assert_eq!(client.world.player_position(), Some(start));
         let body = client
             .world
             .scene

--- a/crates/holtburger-core/src/client/mod.rs
+++ b/crates/holtburger-core/src/client/mod.rs
@@ -1081,15 +1081,15 @@ mod tests {
     fn simulation_build_request_includes_idle_local_player_runtime_body() {
         let mut client = builder::build_test_client(ClientState::InWorld);
         let guid = Guid(0x0102_0304);
+        let player_pose = WorldPosition {
+            landblock_id: Guid(0x1000_0001),
+            coords: Vector3::zero(),
+            rotation: Quaternion::identity(),
+        };
 
-        client.world.player.guid = guid;
-        client.world.player.position.landblock_id = Guid(0x1000_0001);
-        client.world.player.position.rotation = Quaternion::identity();
-        client.world.entities.insert(Entity::new(
-            guid,
-            "Player".to_string(),
-            client.world.player.position,
-        ));
+        client
+            .world
+            .seed_local_player_entity(guid, "Player", player_pose);
 
         let request = client
             .simulation
@@ -1107,7 +1107,7 @@ mod tests {
             body.body_id,
             holtburger_world::SpatialBodyId::LocalPlayer(guid)
         );
-        assert_eq!(body.pose, client.world.player.position);
+        assert_eq!(body.pose, player_pose);
         assert!(matches!(
             body.basis,
             Some(holtburger_world::SolveProjectionBasis::Velocity { velocity, omega })
@@ -1121,15 +1121,15 @@ mod tests {
         let mut client = builder::build_test_client(ClientState::InWorld);
         let guid = Guid(0x0102_0304);
         let now = Instant::now();
+        let player_pose = WorldPosition {
+            landblock_id: Guid(0x1000_0001),
+            coords: Vector3::zero(),
+            rotation: Quaternion::identity(),
+        };
 
-        client.world.player.guid = guid;
-        client.world.player.position.landblock_id = Guid(0x1000_0001);
-        client.world.player.position.rotation = Quaternion::identity();
-        client.world.entities.insert(Entity::new(
-            guid,
-            "Player".to_string(),
-            client.world.player.position,
-        ));
+        client
+            .world
+            .seed_local_player_entity(guid, "Player", player_pose);
 
         client.movement.enqueue_drive_intent(
             movement_types::PlayerDriveIntent::Autonomous(movement_types::AutonomousDriveIntent {
@@ -1185,17 +1185,17 @@ mod tests {
         let mut client = builder::build_test_client(ClientState::InWorld);
         let guid = Guid(0x0102_0304);
         let now = Instant::now();
+        let player_pose = WorldPosition {
+            landblock_id: Guid(0x1000_0001),
+            coords: Vector3::zero(),
+            rotation: Quaternion::identity(),
+        };
 
         seed_test_self_movement_capabilities(&mut client);
 
-        client.world.player.guid = guid;
-        client.world.player.position.landblock_id = Guid(0x1000_0001);
-        client.world.player.position.rotation = Quaternion::identity();
-        client.world.entities.insert(Entity::new(
-            guid,
-            "Player".to_string(),
-            client.world.player.position,
-        ));
+        client
+            .world
+            .seed_local_player_entity(guid, "Player", player_pose);
 
         client.movement.enqueue_drive_intent(
             movement_types::PlayerDriveIntent::ManualHeld(
@@ -1251,17 +1251,17 @@ mod tests {
         let player_guid = Guid(0x0102_0304);
         let remote_guid = Guid(0x0102_0305);
         let now = Instant::now();
+        let player_pose = WorldPosition {
+            landblock_id: Guid(0x1000_0001),
+            coords: Vector3::zero(),
+            rotation: Quaternion::identity(),
+        };
 
         seed_test_self_movement_capabilities(&mut client);
 
-        client.world.player.guid = player_guid;
-        client.world.player.position.landblock_id = Guid(0x1000_0001);
-        client.world.player.position.rotation = Quaternion::identity();
-        client.world.entities.insert(Entity::new(
-            player_guid,
-            "Player".to_string(),
-            client.world.player.position,
-        ));
+        client
+            .world
+            .seed_local_player_entity(player_guid, "Player", player_pose);
         client.world.add_entity(Entity::new(
             remote_guid,
             "Remote".to_string(),
@@ -1333,13 +1333,15 @@ mod tests {
         client
             .world
             .set_motion_kinematics(test_remote_motion_kinematics_asset(motion_table_id));
-        client.world.player.guid = player_guid;
-        client.world.player.position.landblock_id = Guid(0x1000_0001);
-        client.world.entities.insert(Entity::new(
+        client.world.seed_local_player_entity(
             player_guid,
-            "Player".to_string(),
-            client.world.player.position,
-        ));
+            "Player",
+            WorldPosition {
+                landblock_id: Guid(0x1000_0001),
+                coords: Vector3::zero(),
+                rotation: Quaternion::identity(),
+            },
+        );
 
         let mut remote = Entity::new(
             remote_guid,
@@ -1401,17 +1403,17 @@ mod tests {
         let mut client = builder::build_test_client(ClientState::InWorld);
         let guid = Guid(0x0102_0304);
         let now = Instant::now();
+        let player_pose = WorldPosition {
+            landblock_id: Guid(0x1000_0001),
+            coords: Vector3::zero(),
+            rotation: Quaternion::identity(),
+        };
 
         seed_test_self_movement_capabilities(&mut client);
 
-        client.world.player.guid = guid;
-        client.world.player.position.landblock_id = Guid(0x1000_0001);
-        client.world.player.position.rotation = Quaternion::identity();
-        client.world.entities.insert(Entity::new(
-            guid,
-            "Player".to_string(),
-            client.world.player.position,
-        ));
+        client
+            .world
+            .seed_local_player_entity(guid, "Player", player_pose);
 
         client.movement.enqueue_drive_intent(
             movement_types::PlayerDriveIntent::ManualHeld(
@@ -1436,8 +1438,12 @@ mod tests {
             &mut client.movement,
         );
 
-        assert_eq!(client.world.player.position.landblock_id, Guid(0x1000_0001));
-        assert!(client.world.player.position.coords.y.abs() <= f32::EPSILON);
+        let authoritative_pose = client
+            .world
+            .player_position()
+            .expect("local player entity should exist");
+        assert_eq!(authoritative_pose.landblock_id, Guid(0x1000_0001));
+        assert!(authoritative_pose.coords.y.abs() <= f32::EPSILON);
         let body = client
             .world
             .scene
@@ -1458,17 +1464,17 @@ mod tests {
         let player_guid = Guid(0x0102_0304);
         let remote_guid = Guid(0x0102_0305);
         let now = Instant::now();
+        let player_pose = WorldPosition {
+            landblock_id: Guid(0x1000_0001),
+            coords: Vector3::zero(),
+            rotation: Quaternion::identity(),
+        };
 
         seed_test_self_movement_capabilities(&mut client);
 
-        client.world.player.guid = player_guid;
-        client.world.player.position.landblock_id = Guid(0x1000_0001);
-        client.world.player.position.rotation = Quaternion::identity();
-        client.world.entities.insert(Entity::new(
-            player_guid,
-            "Player".to_string(),
-            client.world.player.position,
-        ));
+        client
+            .world
+            .seed_local_player_entity(player_guid, "Player", player_pose);
         client.world.add_entity(Entity::new(
             remote_guid,
             "Remote".to_string(),
@@ -1556,13 +1562,15 @@ mod tests {
         let player_guid = Guid(0x0102_0304);
         let remote_guid = Guid(0x0102_0305);
 
-        client.world.player.guid = player_guid;
-        client.world.player.position.landblock_id = Guid(0x1000_0001);
-        client.world.entities.insert(Entity::new(
+        client.world.seed_local_player_entity(
             player_guid,
-            "Player".to_string(),
-            client.world.player.position,
-        ));
+            "Player",
+            WorldPosition {
+                landblock_id: Guid(0x1000_0001),
+                coords: Vector3::zero(),
+                rotation: Quaternion::identity(),
+            },
+        );
         client.world.add_entity(Entity::new(
             remote_guid,
             "Remote".to_string(),
@@ -1619,13 +1627,15 @@ mod tests {
         client
             .world
             .set_motion_kinematics(test_remote_motion_kinematics_asset(motion_table_id));
-        client.world.player.guid = player_guid;
-        client.world.player.position.landblock_id = Guid(0x1000_0001);
-        client.world.entities.insert(Entity::new(
+        client.world.seed_local_player_entity(
             player_guid,
-            "Player".to_string(),
-            client.world.player.position,
-        ));
+            "Player",
+            WorldPosition {
+                landblock_id: Guid(0x1000_0001),
+                coords: Vector3::zero(),
+                rotation: Quaternion::identity(),
+            },
+        );
 
         let mut remote = Entity::new(
             remote_guid,

--- a/crates/holtburger-core/src/client/mod.rs
+++ b/crates/holtburger-core/src/client/mod.rs
@@ -511,13 +511,11 @@ impl ClientRuntime {
                     .client_view_event_tx
                     .send(ClientViewEvent::PlayerSpellsUpdated { spell_ids });
 
-                if let Some(entity) = &data.player_entity {
-                    let _ = self
-                        .client_view_event_tx
-                        .send(ClientViewEvent::EntitySpawned {
-                            entity: entity.clone(),
-                        });
-                }
+                let _ = self
+                    .client_view_event_tx
+                    .send(ClientViewEvent::EntitySpawned {
+                        entity: data.entity.clone(),
+                    });
                 self.emit_self_movement_kinematics_updated();
             }
             WorldEvent::TeleportStarted { sequence } => {

--- a/crates/holtburger-core/src/client/movement/common.rs
+++ b/crates/holtburger-core/src/client/movement/common.rs
@@ -69,7 +69,7 @@ pub(super) fn raw_motion_state_with_motion_style(
 fn resolve_contact(world: &WorldState, metadata: MovementPacketMetadata) -> bool {
     metadata
         .contact
-        .or(world.player.server_grounded)
+        .or(world.player.last_server_grounded)
         .unwrap_or(true)
 }
 

--- a/crates/holtburger-core/src/client/movement/system.rs
+++ b/crates/holtburger-core/src/client/movement/system.rs
@@ -312,7 +312,8 @@ impl MovementSystem {
     ) -> Option<MotionState> {
         let current_heading = world
             .local_player_runtime_pose()
-            .unwrap_or(world.player.position)
+            .or_else(|| world.player_position())
+            .unwrap_or_default()
             .rotation
             .to_heading();
         let planar_delta = Vector3::new(
@@ -480,7 +481,8 @@ impl MovementSystem {
         if let Some(projection) = self.server_controlled_projection {
             let current_pose = world
                 .local_player_runtime_pose()
-                .unwrap_or(world.player.position);
+                .or_else(|| world.player_position())
+                .unwrap_or_default();
             let to_target = projection.target_pose.global_coords() - current_pose.global_coords();
             let max_step = (projection.speed_mps.max(0.1) * dt.as_secs_f32().max(0.001)).max(0.05);
             let desired_world_delta = if to_target.length_squared() <= 1e-6 {
@@ -542,7 +544,7 @@ impl MovementSystem {
         }
 
         if world.scene.body(SpatialBodyId::LocalPlayer(guid)).is_none()
-            && world.player.position.landblock_id == Guid::NULL
+            && world.player_landblock().is_none()
         {
             return None;
         }
@@ -550,7 +552,7 @@ impl MovementSystem {
         let body_id = SpatialBodyId::LocalPlayer(guid);
         let pose = world
             .local_player_runtime_pose()
-            .unwrap_or(world.player.position);
+            .or_else(|| world.player_position())?;
         let (velocity, omega) = match self.active_drive.map(|active| active.intent) {
             Some(ActiveDriveIntent::Manual(state)) => {
                 let heading = pose.rotation.to_heading();
@@ -878,7 +880,8 @@ impl MovementSystem {
             ),
             position: world
                 .local_player_runtime_pose()
-                .unwrap_or(world.player.position),
+                .or_else(|| world.player_position())
+                .unwrap_or_default(),
             instance_sequence: world.player.instance_sequence,
             server_control_sequence: world.player.server_control_sequence,
             teleport_sequence: world.player.teleport_sequence,
@@ -904,7 +907,8 @@ impl MovementSystem {
             ),
             position: world
                 .local_player_runtime_pose()
-                .unwrap_or(world.player.position),
+                .or_else(|| world.player_position())
+                .unwrap_or_default(),
             instance_sequence: world.player.instance_sequence,
             server_control_sequence: world.player.server_control_sequence,
             teleport_sequence: world.player.teleport_sequence,

--- a/crates/holtburger-core/src/client/movement/system.rs
+++ b/crates/holtburger-core/src/client/movement/system.rs
@@ -312,7 +312,6 @@ impl MovementSystem {
     ) -> Option<MotionState> {
         let current_heading = world
             .local_player_runtime_pose()
-            .or_else(|| world.player_position())
             .unwrap_or_default()
             .rotation
             .to_heading();
@@ -479,10 +478,7 @@ impl MovementSystem {
         let body_id = SpatialBodyId::LocalPlayer(world.player.guid);
 
         if let Some(projection) = self.server_controlled_projection {
-            let current_pose = world
-                .local_player_runtime_pose()
-                .or_else(|| world.player_position())
-                .unwrap_or_default();
+            let current_pose = world.local_player_runtime_pose().unwrap_or_default();
             let to_target = projection.target_pose.global_coords() - current_pose.global_coords();
             let max_step = (projection.speed_mps.max(0.1) * dt.as_secs_f32().max(0.001)).max(0.05);
             let desired_world_delta = if to_target.length_squared() <= 1e-6 {
@@ -550,9 +546,7 @@ impl MovementSystem {
         }
 
         let body_id = SpatialBodyId::LocalPlayer(guid);
-        let pose = world
-            .local_player_runtime_pose()
-            .or_else(|| world.player_position())?;
+        let pose = world.local_player_runtime_pose()?;
         let (velocity, omega) = match self.active_drive.map(|active| active.intent) {
             Some(ActiveDriveIntent::Manual(state)) => {
                 let heading = pose.rotation.to_heading();
@@ -878,10 +872,7 @@ impl MovementSystem {
                 state,
                 metadata.motion_style,
             ),
-            position: world
-                .local_player_runtime_pose()
-                .or_else(|| world.player_position())
-                .unwrap_or_default(),
+            position: world.local_player_runtime_pose().unwrap_or_default(),
             instance_sequence: world.player.instance_sequence,
             server_control_sequence: world.player.server_control_sequence,
             teleport_sequence: world.player.teleport_sequence,
@@ -905,10 +896,7 @@ impl MovementSystem {
                 RawMotionState::default(),
                 metadata.motion_style,
             ),
-            position: world
-                .local_player_runtime_pose()
-                .or_else(|| world.player_position())
-                .unwrap_or_default(),
+            position: world.local_player_runtime_pose().unwrap_or_default(),
             instance_sequence: world.player.instance_sequence,
             server_control_sequence: world.player.server_control_sequence,
             teleport_sequence: world.player.teleport_sequence,

--- a/crates/holtburger-core/src/client/movement/system/tests.rs
+++ b/crates/holtburger-core/src/client/movement/system/tests.rs
@@ -637,7 +637,7 @@ fn autonomous_position_uses_server_grounded_when_contact_unspecified() {
     entity.velocity = Vector3::new(2.0, 0.0, 0.0);
 
     world.player.guid = guid;
-    world.player.server_grounded = Some(true);
+    world.player.last_server_grounded = Some(true);
     seed_local_player(&mut world, guid, position);
     world.entities.insert(entity);
 

--- a/crates/holtburger-core/src/client/movement/system/tests.rs
+++ b/crates/holtburger-core/src/client/movement/system/tests.rs
@@ -49,6 +49,10 @@ fn seed_player_run_rate_scalar(world: &mut WorldState, run_skill: u32) -> f32 {
     player_run_rate_scalar(world)
 }
 
+fn seed_local_player(world: &mut WorldState, guid: Guid, position: WorldPosition) {
+    world.seed_local_player_entity(guid, "Player", position);
+}
+
 fn seed_self_movement_capabilities_override(
     world: &mut WorldState,
     run_rate_scalar: f32,
@@ -81,9 +85,9 @@ fn autonomous_wire_motion_state_uses_forward_without_turn_when_moving() {
         Guid(0x5000_0123),
         "Player",
         WorldPosition {
-        landblock_id: Guid(0x1234_0000),
-        coords: Vector3::new(10.0, 20.0, 0.0),
-        rotation: Quaternion::from_heading(0.0),
+            landblock_id: Guid(0x1234_0000),
+            coords: Vector3::new(10.0, 20.0, 0.0),
+            rotation: Quaternion::from_heading(0.0),
         },
     );
 
@@ -111,9 +115,9 @@ fn autonomous_wire_motion_state_can_turn_in_place() {
         Guid(0x5000_0123),
         "Player",
         WorldPosition {
-        landblock_id: Guid(0x1234_0000),
-        coords: Vector3::new(10.0, 20.0, 0.0),
-        rotation: Quaternion::from_heading(0.0),
+            landblock_id: Guid(0x1234_0000),
+            coords: Vector3::new(10.0, 20.0, 0.0),
+            rotation: Quaternion::from_heading(0.0),
         },
     );
 
@@ -141,9 +145,9 @@ fn autonomous_wire_motion_state_skips_idle_aligned_requests() {
         Guid(0x5000_0123),
         "Player",
         WorldPosition {
-        landblock_id: Guid(0x1234_0000),
-        coords: Vector3::new(10.0, 20.0, 0.0),
-        rotation: Quaternion::from_heading(0.0),
+            landblock_id: Guid(0x1234_0000),
+            coords: Vector3::new(10.0, 20.0, 0.0),
+            rotation: Quaternion::from_heading(0.0),
         },
     );
 
@@ -481,19 +485,15 @@ fn current_local_solve_body_input_uses_shared_resolved_manual_run_speed() {
     world.player.guid = player_guid;
     let capabilities = seed_self_movement_capabilities_override(&mut world, 3.25, 1.0, 2.0, 1.25);
     let expected_local_run_speed = capabilities.resolved_manual_run_speed();
-    world.player.position = WorldPosition {
+    let mut position = WorldPosition {
         landblock_id: Guid(0x12340000),
         coords: Vector3::new(10.0, 20.0, 0.0),
         rotation: Quaternion::identity(),
     };
-    world.entities.insert(Entity::new(
-        player_guid,
-        "Player".to_string(),
-        world.player.position,
-    ));
+    seed_local_player(&mut world, player_guid, position);
 
-    world.player.position.rotation = Quaternion::from_heading(90.0_f32.to_radians());
-    let _ = world.set_player_position(world.player.position);
+    position.rotation = Quaternion::from_heading(90.0_f32.to_radians());
+    let _ = world.set_player_position(position);
 
     let mut movement = MovementSystem::new();
     movement.active_drive = Some(ActiveDriveState::manual(
@@ -520,16 +520,12 @@ fn current_local_solve_body_input_uses_shared_turn_omega_for_turn_in_place() {
     let player_guid = Guid(0x50000123);
     world.player.guid = player_guid;
     let capabilities = seed_self_movement_capabilities_override(&mut world, 3.25, 1.0, 2.0, 1.25);
-    world.player.position = WorldPosition {
+    let position = WorldPosition {
         landblock_id: Guid(0x12340000),
         coords: Vector3::new(10.0, 20.0, 0.0),
         rotation: Quaternion::identity(),
     };
-    world.entities.insert(Entity::new(
-        player_guid,
-        "Player".to_string(),
-        world.player.position,
-    ));
+    seed_local_player(&mut world, player_guid, position);
 
     let mut movement = MovementSystem::new();
     movement.active_drive = Some(ActiveDriveState::manual(
@@ -610,11 +606,11 @@ fn autonomous_position_heartbeat_defaults_to_grounded_when_contact_unknown() {
     entity.velocity = Vector3::new(2.0, 0.0, 0.0);
 
     world.player.guid = guid;
-    world.player.position = position;
     world.player.instance_sequence = 11;
     world.player.server_control_sequence = 22;
     world.player.teleport_sequence = 33;
     world.player.force_position_sequence = 44;
+    seed_local_player(&mut world, guid, position);
     world.entities.insert(entity);
 
     let position_action = build_autonomous_position(&world, MovementPacketMetadata::default())
@@ -641,8 +637,8 @@ fn autonomous_position_uses_server_grounded_when_contact_unspecified() {
     entity.velocity = Vector3::new(2.0, 0.0, 0.0);
 
     world.player.guid = guid;
-    world.player.position = position;
     world.player.server_grounded = Some(true);
+    seed_local_player(&mut world, guid, position);
     world.entities.insert(entity);
 
     let position_action = build_autonomous_position(&world, MovementPacketMetadata::default())
@@ -664,7 +660,7 @@ fn autonomous_position_can_be_built_for_turn_only_motion() {
     entity.omega = Vector3::new(0.0, 0.0, 1.0);
 
     world.player.guid = guid;
-    world.player.position = position;
+    seed_local_player(&mut world, guid, position);
     world.entities.insert(entity);
 
     let position_action = build_autonomous_position(&world, MovementPacketMetadata::default())
@@ -684,14 +680,11 @@ fn autonomous_position_can_be_built_for_stationary_player() {
     };
 
     world.player.guid = guid;
-    world.player.position = position;
     world.player.instance_sequence = 11;
     world.player.server_control_sequence = 22;
     world.player.teleport_sequence = 33;
     world.player.force_position_sequence = 44;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let position_action = build_autonomous_position(&world, MovementPacketMetadata::default())
         .expect("autonomous position action should emit even when stationary");
@@ -715,7 +708,7 @@ async fn stop_after_active_drive_sends_stop_pulse_then_final_position_sync() {
     let mut entity = Entity::new(guid, "Player".to_string(), position);
 
     world.player.guid = guid;
-    world.player.position = position;
+    seed_local_player(&mut world, guid, position);
     world.entities.insert(entity.clone());
 
     let mut movement = MovementSystem::new();
@@ -759,10 +752,7 @@ async fn stop_without_active_drive_does_not_send_final_position_sync() {
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -796,10 +786,7 @@ async fn unchanged_motion_state_requests_do_not_resend_motion_pulses() {
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -843,10 +830,7 @@ async fn held_run_input_ticks_once_for_wire_and_keeps_local_vectors_consistent()
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -899,10 +883,7 @@ async fn pulsed_run_input_expires_on_tick_and_sends_stop_transition() {
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -947,10 +928,7 @@ async fn server_controlled_movement_suppresses_next_frontend_autonomous_wire_pul
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -993,10 +971,7 @@ fn server_controlled_projection_uses_landblock_aware_global_delta() {
     };
 
     world.player.guid = guid;
-    world.player.position = current_pose;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), current_pose));
+    seed_local_player(&mut world, guid, current_pose);
 
     let mut movement = MovementSystem::new();
     movement.set_server_controlled_projection(ServerControlledProjection {
@@ -1027,10 +1002,7 @@ async fn stop_input_clears_held_run_and_sends_stop_transition() {
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -1071,10 +1043,7 @@ async fn autonomous_drive_gap_does_not_send_stop_pulse_without_explicit_stop() {
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -1116,10 +1085,7 @@ async fn explicit_stop_after_autonomous_drive_sends_stop_pulse() {
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -1160,10 +1126,7 @@ async fn snap_facing_sends_autonomous_position_sync_with_updated_rotation() {
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -1204,10 +1167,7 @@ async fn arrival_pose_sync_updates_runtime_pose_and_clears_server_motion() {
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -1257,9 +1217,7 @@ async fn movement_heartbeat_arms_then_sends_for_stationary_player_with_valid_pos
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    let entity = Entity::new(guid, "Player".to_string(), position);
-    world.entities.insert(entity);
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -1327,7 +1285,7 @@ async fn armed_movement_heartbeat_stays_armed_when_player_stops_moving() {
     entity.velocity = Vector3::new(1.0, 0.0, 0.0);
 
     world.player.guid = guid;
-    world.player.position = position;
+    seed_local_player(&mut world, guid, position);
     world.entities.insert(entity);
 
     let mut movement = MovementSystem::new();
@@ -1382,7 +1340,7 @@ async fn movement_tick_emits_autonomous_position_heartbeat_when_due() {
     entity.velocity = Vector3::new(2.0, 0.0, 0.0);
 
     world.player.guid = guid;
-    world.player.position = position;
+    seed_local_player(&mut world, guid, position);
     world.entities.insert(entity);
 
     let mut movement = MovementSystem::new();
@@ -1419,10 +1377,7 @@ async fn stop_without_active_drive_keeps_autonomous_position_heartbeat_armed() {
     };
 
     world.player.guid = guid;
-    world.player.position = position;
-    world
-        .entities
-        .insert(Entity::new(guid, "Player".to_string(), position));
+    seed_local_player(&mut world, guid, position);
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();

--- a/crates/holtburger-core/src/client/movement/system/tests.rs
+++ b/crates/holtburger-core/src/client/movement/system/tests.rs
@@ -77,11 +77,15 @@ fn seed_self_movement_capabilities_override(
 #[test]
 fn autonomous_wire_motion_state_uses_forward_without_turn_when_moving() {
     let mut world = WorldState::synthetic();
-    world.player.position = WorldPosition {
+    world.seed_local_player_entity(
+        Guid(0x5000_0123),
+        "Player",
+        WorldPosition {
         landblock_id: Guid(0x1234_0000),
         coords: Vector3::new(10.0, 20.0, 0.0),
         rotation: Quaternion::from_heading(0.0),
-    };
+        },
+    );
 
     let state = MovementSystem::autonomous_wire_motion_state(
         &world,
@@ -103,11 +107,15 @@ fn autonomous_wire_motion_state_uses_forward_without_turn_when_moving() {
 #[test]
 fn autonomous_wire_motion_state_can_turn_in_place() {
     let mut world = WorldState::synthetic();
-    world.player.position = WorldPosition {
+    world.seed_local_player_entity(
+        Guid(0x5000_0123),
+        "Player",
+        WorldPosition {
         landblock_id: Guid(0x1234_0000),
         coords: Vector3::new(10.0, 20.0, 0.0),
         rotation: Quaternion::from_heading(0.0),
-    };
+        },
+    );
 
     let state = MovementSystem::autonomous_wire_motion_state(
         &world,
@@ -129,11 +137,15 @@ fn autonomous_wire_motion_state_can_turn_in_place() {
 #[test]
 fn autonomous_wire_motion_state_skips_idle_aligned_requests() {
     let mut world = WorldState::synthetic();
-    world.player.position = WorldPosition {
+    world.seed_local_player_entity(
+        Guid(0x5000_0123),
+        "Player",
+        WorldPosition {
         landblock_id: Guid(0x1234_0000),
         coords: Vector3::new(10.0, 20.0, 0.0),
         rotation: Quaternion::from_heading(0.0),
-    };
+        },
+    );
 
     let state = MovementSystem::autonomous_wire_motion_state(
         &world,
@@ -152,13 +164,14 @@ fn autonomous_wire_motion_state_skips_idle_aligned_requests() {
 #[tokio::test]
 async fn enqueue_drive_intent_exposes_autonomous_drive_for_current_tick_only() {
     let mut world = WorldState::synthetic();
-    world.player.guid = Guid(0x5000_0123);
-    world.player.position.landblock_id = Guid(0x1234_0000);
-    world.entities.insert(Entity::new(
-        world.player.guid,
-        "Player".to_string(),
-        world.player.position,
-    ));
+    world.seed_local_player_entity(
+        Guid(0x5000_0123),
+        "Player",
+        WorldPosition {
+            landblock_id: Guid(0x1234_0000),
+            ..Default::default()
+        },
+    );
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();
@@ -220,13 +233,14 @@ async fn enqueue_drive_intent_exposes_autonomous_drive_for_current_tick_only() {
 #[tokio::test]
 async fn later_manual_drive_wins_over_queued_autonomous_drive() {
     let mut world = WorldState::synthetic();
-    world.player.guid = Guid(0x5000_0123);
-    world.player.position.landblock_id = Guid(0x1234_0000);
-    world.entities.insert(Entity::new(
-        world.player.guid,
-        "Player".to_string(),
-        world.player.position,
-    ));
+    world.seed_local_player_entity(
+        Guid(0x5000_0123),
+        "Player",
+        WorldPosition {
+            landblock_id: Guid(0x1234_0000),
+            ..Default::default()
+        },
+    );
 
     let mut movement = MovementSystem::new();
     let mut session = Session::new_test();

--- a/crates/holtburger-core/src/client/runtime.rs
+++ b/crates/holtburger-core/src/client/runtime.rs
@@ -11,11 +11,7 @@ impl ClientRuntime {
     }
 
     fn sync_remote_body_tracking(&mut self, body_id: SpatialBodyId) {
-        let Some(guid) = body_id.authoritative_guid() else {
-            return;
-        };
-
-        if guid == self.world.player.guid {
+        if matches!(body_id, SpatialBodyId::LocalPlayer(_)) {
             return;
         }
 
@@ -78,7 +74,7 @@ impl ClientRuntime {
                 self.sync_remote_body_tracking(*body_id);
             }
             WorldEvent::RuntimeBodyRemoved { body_id }
-                if body_id.authoritative_guid().is_some() =>
+                if !matches!(body_id, SpatialBodyId::LocalPlayer(_)) =>
             {
                 self.simulation.untrack_body(*body_id);
             }

--- a/crates/holtburger-core/src/client/simulation.rs
+++ b/crates/holtburger-core/src/client/simulation.rs
@@ -363,9 +363,7 @@ mod tests {
     fn synthetic_player_world(start: WorldPosition) -> (WorldState, Guid) {
         let mut world = WorldState::synthetic();
         let player_guid = Guid(0x5000_0001);
-        world.player.guid = player_guid;
-        world.player.position = start;
-        world.add_entity(Entity::new(player_guid, "Player".to_string(), start));
+        world.seed_local_player_entity(player_guid, "Player", start);
         (world, player_guid)
     }
 
@@ -381,21 +379,12 @@ mod tests {
             rotation: Quaternion::identity(),
         };
 
-        world.player.guid = player_guid;
-        world.player.position = WorldPosition {
+        let player_pose = WorldPosition {
             landblock_id: Guid(0x1234_0000),
             ..Default::default()
         };
-        world.add_entity(Entity::new(
-            player_guid,
-            "Player".to_string(),
-            world.player.position,
-        ));
-        world.add_entity(Entity::new(
-            remote_guid,
-            "Remote".to_string(),
-            world.player.position,
-        ));
+        world.seed_local_player_entity(player_guid, "Player", player_pose);
+        world.add_entity(Entity::new(remote_guid, "Remote".to_string(), player_pose));
 
         let events = simulation.apply_solve_batch(
             &mut world,

--- a/crates/holtburger-core/src/client/simulation.rs
+++ b/crates/holtburger-core/src/client/simulation.rs
@@ -403,7 +403,7 @@ mod tests {
             },
         );
 
-        assert_eq!(world.player.server_grounded, Some(true));
+        assert_eq!(world.player.last_server_grounded, Some(true));
         assert_eq!(
             world
                 .scene

--- a/crates/holtburger-world/ARCHITECTURE.md
+++ b/crates/holtburger-world/ARCHITECTURE.md
@@ -90,7 +90,7 @@ These modules own movement-facing invariants:
 `SpatialScene` is the world-owned spatial composite and solve/query context. Shared runtime
 sampling behavior lives inside it via `BodySamplingStore`, and that world-owned sampling state is
 the canonical runtime body model for the client. Any app-facing cache in `holtburger-core` or a
-frontend is mirrored read state only; it must not independently advance runtime bodies.
+frontend is derived read state only; it must not independently advance runtime bodies.
 
 Shared world no longer performs automatic local collision or local velocity integration during
 `tick()`. Those semantics are intentionally deferred until a future client can define a real

--- a/crates/holtburger-world/ARCHITECTURE.md
+++ b/crates/holtburger-world/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # World State Architecture 🌍
 
 `holtburger-world` is the client's authoritative in-memory world model. It owns the live player
-model, hydrated entities, spatial index, lifecycle/retention rules, and world-domain state, while
+entity, hydrated entities, spatial index, lifecycle/retention rules, and world-domain state, while
 keeping protocol routing separate from the state models themselves.
 
 The refactor goal was simple: **handlers orchestrate, models mutate**.
@@ -16,8 +16,8 @@ The refactor goal was simple: **handlers orchestrate, models mutate**.
     now just a facade over the handler layer.
 - **Narrow mutation surfaces**: handlers call focused mutation helpers on `PlayerState` and
     `WorldState` instead of open-coding state changes.
-- **Mirror invariants matter**: the current player is mirrored between `PlayerState` and the player
-    `Entity` in `WorldState.entities`; movement/placement helpers must keep those views synchronized.
+- **One world authority**: player world/object state lives on the player `Entity` in
+    `WorldState.entities`; `PlayerState` is reserved for local-player/session overlays.
 - **Retention is part of authority**: whether an entity stays visible to the client is determined by
     `WorldState` retention/lifecycle rules, not by ad hoc handler-local cleanup.
 
@@ -49,7 +49,7 @@ File: [src/player/mod.rs](src/player/mod.rs)
 - attributes, vitals, skills, and their raw bases
 - enchantments, spells, hotbars, and derived combat stats
 - inventory/equipment membership
-- player properties and protocol sequence tracking
+- player-local position properties and protocol sequence tracking
 - bootstrap hydration for player-local `PlayerDescription` data
 
 `PlayerState` does **not** own the top-level message router anymore. Its job is to expose mutation
@@ -85,7 +85,7 @@ These modules own movement-facing invariants:
 - player/entity movement synchronization
 - retention/visibility housekeeping for the world graph
 - conservative visibility tracking for prune deadlines
-- player mirror helpers such as `set_player_position()` and `set_player_vector()`
+- authoritative player-entity helpers such as `set_player_position()` and `set_player_vector()`
 
 `SpatialScene` is the world-owned spatial composite and solve/query context. Shared runtime
 sampling behavior lives inside it via `BodySamplingStore`, and that world-owned sampling state is
@@ -152,14 +152,12 @@ sequenceDiagram
 
 ## Important Invariants
 
-### Player mirror invariant
-The current player exists in two forms:
+### Player authority invariant
+The current player's world/object state lives on the player entity in `WorldState.entities`.
 
-- the session-local player model in `WorldState.player`
-- the physical entity entry in `WorldState.entities`
-
-Anything that changes the player's physical position or velocity must keep both views in sync.
-Prefer `WorldState` movement helpers over direct field writes.
+Anything that changes the player's physical position or velocity must update that entity through
+the `WorldState` movement helpers so the authoritative entity state and the runtime-body state stay
+in sync. `PlayerState` is for local-player overlays and sequencing, not duplicate world storage.
 
 ### Handler boundary
 Handlers should orchestrate domain flows; they should not become mini state stores.
@@ -171,7 +169,7 @@ type instead of open-coding the mutation logic again.
 `PlayerDescription` is intentionally a shared flow:
 
 - the `player` handler hydrates the session-local player model first
-- the `login` handler then mirrors world-facing details and emits `PlayerInfo`/`LevelInfo`
+- the `login` handler then hydrates the authoritative player entity and emits `PlayerInfo`/`LevelInfo`
 
 That ordering avoids world helpers reading partially hydrated player state.
 

--- a/crates/holtburger-world/ARCHITECTURE.md
+++ b/crates/holtburger-world/ARCHITECTURE.md
@@ -49,11 +49,12 @@ File: [src/player/mod.rs](src/player/mod.rs)
 - attributes, vitals, skills, and their raw bases
 - enchantments, spells, hotbars, and derived combat stats
 - inventory/equipment membership
-- player-local position properties and protocol sequence tracking
+- player-local position overlays and protocol sequence tracking
 - bootstrap hydration for player-local `PlayerDescription` data
 
-`PlayerState` does **not** own the top-level message router anymore. Its job is to expose mutation
-helpers that encode player-local invariants, sequence tracking, and derived-stat recalculation.
+`PlayerState` does **not** own the top-level message router anymore, and it is not a second
+authoritative entity snapshot. Its job is to expose mutation helpers that encode player-local
+invariants, sequence tracking, and derived-stat recalculation.
 
 ### `WorldState` — authoritative world graph
 File: [src/state/mod.rs](src/state/mod.rs)

--- a/crates/holtburger-world/src/context.rs
+++ b/crates/holtburger-world/src/context.rs
@@ -129,8 +129,7 @@ impl WorldContext for WorldState {
     }
 
     fn get_player_int_property(&self, prop: PropertyInt) -> Option<i32> {
-        self.player_properties()
-            .and_then(|properties| properties.get_int_prop(prop))
+        self.player_int_property(prop)
     }
 }
 

--- a/crates/holtburger-world/src/context.rs
+++ b/crates/holtburger-world/src/context.rs
@@ -129,7 +129,8 @@ impl WorldContext for WorldState {
     }
 
     fn get_player_int_property(&self, prop: PropertyInt) -> Option<i32> {
-        self.player.get_int_prop(prop)
+        self.player_properties()
+            .and_then(|properties| properties.get_int_prop(prop))
     }
 }
 

--- a/crates/holtburger-world/src/events.rs
+++ b/crates/holtburger-world/src/events.rs
@@ -13,10 +13,8 @@ use holtburger_protocol::messages::magic::Enchantment;
 
 #[derive(Debug, Clone)]
 pub struct PlayerInfoData {
-    pub guid: Guid,
-    pub name: String,
-    pub pos: Option<WorldPosition>,
-    pub player_entity: Option<Box<Entity>>,
+    /// Authoritative world/entity snapshot for the local player.
+    pub entity: Box<Entity>,
     pub attributes: Vec<stats::Attribute>,
     pub vitals: Vec<stats::Vital>,
     pub skills: Vec<stats::Skill>,

--- a/crates/holtburger-world/src/handlers/inventory.rs
+++ b/crates/holtburger-world/src/handlers/inventory.rs
@@ -198,16 +198,16 @@ pub(crate) fn handle_event(
         GameEvent::BookPageDataResponse(data) => {
             let guid = data.object_guid;
             if let Some(entity) = state.entities.get_mut(guid) {
-                entity
-                    .book
-                    .get_or_insert_with(BookData::default)
-                    .apply_page_response(data);
-                if let Some(book) = entity.book.clone() {
-                    events.push(WorldEvent::EntityBookUpdated {
-                        guid,
-                        book: Box::new(book),
-                    });
-                }
+                let book = {
+                    let book = entity.book.get_or_insert_with(BookData::default);
+                    book.apply_page_response(data);
+                    book.clone()
+                };
+
+                events.push(WorldEvent::EntityBookUpdated {
+                    guid,
+                    book: Box::new(book),
+                });
                 true
             } else {
                 false

--- a/crates/holtburger-world/src/handlers/login.rs
+++ b/crates/holtburger-world/src/handlers/login.rs
@@ -9,7 +9,7 @@ pub(crate) fn handle_event(
 ) -> bool {
     match &event.event {
         GameEvent::PlayerDescription(data) => {
-            state.apply_player_description_world_state(data.guid, &data.name, data.pos, events);
+            state.apply_player_description_world_state(data, events);
             true
         }
         _ => false,

--- a/crates/holtburger-world/src/handlers/movement.rs
+++ b/crates/holtburger-world/src/handlers/movement.rs
@@ -72,7 +72,10 @@ pub(crate) fn handle_message(
             }
 
             let current_position = if guid == state.player.guid {
-                state.player.position
+                match state.player_position() {
+                    Some(position) => position,
+                    None => return false,
+                }
             } else {
                 match state.entities.get(guid) {
                     Some(entity) => entity.position,
@@ -106,7 +109,9 @@ pub(crate) fn handle_message(
 
             if let Some(rotation) = maybe_rotation {
                 if guid == state.player.guid {
-                    let mut pos = state.player.position;
+                    let Some(mut pos) = state.player_position() else {
+                        return false;
+                    };
                     pos.rotation = rotation;
                     events.extend(state.set_player_position(pos));
                     true

--- a/crates/holtburger-world/src/handlers/movement.rs
+++ b/crates/holtburger-world/src/handlers/movement.rs
@@ -71,16 +71,9 @@ pub(crate) fn handle_message(
                 target_info = Some((target.position.landblock_id, target.position.coords));
             }
 
-            let current_position = if guid == state.player.guid {
-                match state.player_position() {
-                    Some(position) => position,
-                    None => return false,
-                }
-            } else {
-                match state.entities.get(guid) {
-                    Some(entity) => entity.position,
-                    None => return false,
-                }
+            let current_position = match state.entities.get(guid) {
+                Some(entity) => entity.position,
+                None => return false,
             };
 
             let maybe_rotation = match &data.data {
@@ -108,16 +101,7 @@ pub(crate) fn handle_message(
             };
 
             if let Some(rotation) = maybe_rotation {
-                if guid == state.player.guid {
-                    let Some(mut pos) = state.player_position() else {
-                        return false;
-                    };
-                    pos.rotation = rotation;
-                    events.extend(state.set_player_position(pos));
-                    true
-                } else {
-                    state.set_entity_rotation(guid, rotation, events)
-                }
+                state.set_entity_rotation(guid, rotation, events)
             } else {
                 false
             }

--- a/crates/holtburger-world/src/handlers/player.rs
+++ b/crates/holtburger-world/src/handlers/player.rs
@@ -88,6 +88,7 @@ pub(crate) fn handle_message(
             state
                 .player
                 .update_attribute(*attribute, *ranks, *start, *xp, &state.xp_table, events);
+            state.emit_player_derived_stats(events);
             true
         }
         GameMessage::PublicUpdateAttribute(data) => {
@@ -101,6 +102,7 @@ pub(crate) fn handle_message(
             state
                 .player
                 .update_attribute(*attribute, *ranks, *start, *xp, &state.xp_table, events);
+            state.emit_player_derived_stats(events);
             true
         }
         GameMessage::PrivateUpdateSkill(data) => {
@@ -124,6 +126,7 @@ pub(crate) fn handle_message(
                 },
                 events,
             );
+            state.emit_player_derived_stats(events);
             true
         }
         GameMessage::PublicUpdateSkill(data) => {
@@ -147,6 +150,7 @@ pub(crate) fn handle_message(
                 },
                 events,
             );
+            state.emit_player_derived_stats(events);
             true
         }
         GameMessage::PrivateUpdateVital(data) => {
@@ -169,6 +173,7 @@ pub(crate) fn handle_message(
                 },
                 events,
             );
+            state.emit_player_derived_stats(events);
             true
         }
         GameMessage::PublicUpdateVital(data) => {
@@ -191,6 +196,7 @@ pub(crate) fn handle_message(
                 },
                 events,
             );
+            state.emit_player_derived_stats(events);
             true
         }
         GameMessage::PrivateUpdateVitalCurrent(data) => {
@@ -220,37 +226,81 @@ pub(crate) fn handle_event(
                 &state.skill_table,
                 events,
             );
+            state.emit_player_derived_stats(events);
             false
         }
         GameEvent::MagicUpdateEnchantment(data) => {
-            state
+            let handled = state
                 .player
-                .upsert_enchantment(data.target, data.enchantment, events)
+                .upsert_enchantment(data.target, data.enchantment, events);
+            if handled {
+                state.emit_player_derived_stats(events);
+            }
+            handled
         }
-        GameEvent::MagicUpdateMultipleEnchantments(data) => state
-            .player
-            .upsert_multiple_enchantments(data.target, &data.enchantments, events),
+        GameEvent::MagicUpdateMultipleEnchantments(data) => {
+            let handled =
+                state
+                    .player
+                    .upsert_multiple_enchantments(data.target, &data.enchantments, events);
+            if handled {
+                state.emit_player_derived_stats(events);
+            }
+            handled
+        }
         GameEvent::MagicRemoveEnchantment(data) => {
-            state
-                .player
-                .remove_enchantment(data.target, data.spell_id, data.layer, events)
+            let handled =
+                state
+                    .player
+                    .remove_enchantment(data.target, data.spell_id, data.layer, events);
+            if handled {
+                state.emit_player_derived_stats(events);
+            }
+            handled
         }
         GameEvent::MagicDispelEnchantment(data) => {
-            state
-                .player
-                .remove_enchantment(data.target, data.spell_id, data.layer, events)
+            let handled =
+                state
+                    .player
+                    .remove_enchantment(data.target, data.spell_id, data.layer, events);
+            if handled {
+                state.emit_player_derived_stats(events);
+            }
+            handled
         }
-        GameEvent::MagicRemoveMultipleEnchantments(data) => state
-            .player
-            .remove_multiple_enchantments(data.target, &data.spells, events),
-        GameEvent::MagicDispelMultipleEnchantments(data) => state
-            .player
-            .remove_multiple_enchantments(data.target, &data.spells, events),
+        GameEvent::MagicRemoveMultipleEnchantments(data) => {
+            let handled =
+                state
+                    .player
+                    .remove_multiple_enchantments(data.target, &data.spells, events);
+            if handled {
+                state.emit_player_derived_stats(events);
+            }
+            handled
+        }
+        GameEvent::MagicDispelMultipleEnchantments(data) => {
+            let handled =
+                state
+                    .player
+                    .remove_multiple_enchantments(data.target, &data.spells, events);
+            if handled {
+                state.emit_player_derived_stats(events);
+            }
+            handled
+        }
         GameEvent::MagicPurgeEnchantments(data) => {
-            state.player.purge_enchantments(data.target, false, events)
+            let handled = state.player.purge_enchantments(data.target, false, events);
+            if handled {
+                state.emit_player_derived_stats(events);
+            }
+            handled
         }
         GameEvent::MagicPurgeBadEnchantments(data) => {
-            state.player.purge_enchantments(data.target, true, events)
+            let handled = state.player.purge_enchantments(data.target, true, events);
+            if handled {
+                state.emit_player_derived_stats(events);
+            }
+            handled
         }
         GameEvent::MagicUpdateSpell(data) => {
             state.player.add_spell(data.spell_id as u32, events);

--- a/crates/holtburger-world/src/handlers/properties.rs
+++ b/crates/holtburger-world/src/handlers/properties.rs
@@ -31,7 +31,7 @@ pub(crate) fn handle_message(
         }
         GameMessage::PrivateUpdatePropertyInt(data) => {
             let update = PropertyUpdate::try_from_raw_int(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             if target_guid == state.player.guid {
                 match data.property {
                     p if p == PropertyInt::Level as u32
@@ -40,17 +40,11 @@ pub(crate) fn handle_message(
                         state.emit_level_info(events);
                     }
                     p if p == PropertyInt::CombatMode as u32 => {
-                        if let Some(mode) =
-                            holtburger_protocol::messages::combat::CombatMode::from_repr(
-                                data.value as u32,
-                            )
-                        {
-                            events.push(WorldEvent::CombatModeUpdated(mode));
-                        }
+                        events.push(WorldEvent::CombatModeUpdated(state.player_combat_mode()));
                     }
                     _ => {}
                 }
-                state.player.emit_derived_stats(events);
+                state.emit_player_derived_stats(events);
             }
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
@@ -60,16 +54,12 @@ pub(crate) fn handle_message(
         }
         GameMessage::PublicUpdatePropertyInt(data) => {
             let update = PropertyUpdate::try_from_raw_int(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             if target_guid == state.player.guid {
-                if data.property == PropertyInt::CombatMode as u32
-                    && let Some(mode) = holtburger_protocol::messages::combat::CombatMode::from_repr(
-                        data.value as u32,
-                    )
-                {
-                    events.push(WorldEvent::CombatModeUpdated(mode));
+                if data.property == PropertyInt::CombatMode as u32 {
+                    events.push(WorldEvent::CombatModeUpdated(state.player_combat_mode()));
                 }
-                state.player.emit_derived_stats(events);
+                state.emit_player_derived_stats(events);
             }
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
@@ -79,7 +69,7 @@ pub(crate) fn handle_message(
         }
         GameMessage::PrivateUpdatePropertyInt64(data) => {
             let update = PropertyUpdate::try_from_raw_int64(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             if target_guid == state.player.guid {
                 match data.property {
                     p if p
@@ -102,7 +92,7 @@ pub(crate) fn handle_message(
         }
         GameMessage::PublicUpdatePropertyInt64(data) => {
             let update = PropertyUpdate::try_from_raw_int64(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, false);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
                 updates: vec![update],
@@ -111,7 +101,7 @@ pub(crate) fn handle_message(
         }
         GameMessage::PrivateUpdatePropertyBool(data) => {
             let update = PropertyUpdate::try_from_raw_bool(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
                 updates: vec![update],
@@ -120,7 +110,7 @@ pub(crate) fn handle_message(
         }
         GameMessage::PublicUpdatePropertyBool(data) => {
             let update = PropertyUpdate::try_from_raw_bool(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
                 updates: vec![update],
@@ -129,9 +119,9 @@ pub(crate) fn handle_message(
         }
         GameMessage::PrivateUpdatePropertyFloat(data) => {
             let update = PropertyUpdate::try_from_raw_float(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             if target_guid == state.player.guid {
-                state.player.emit_derived_stats(events);
+                state.emit_player_derived_stats(events);
             }
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
@@ -141,9 +131,9 @@ pub(crate) fn handle_message(
         }
         GameMessage::PublicUpdatePropertyFloat(data) => {
             let update = PropertyUpdate::try_from_raw_float(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             if target_guid == state.player.guid {
-                state.player.emit_derived_stats(events);
+                state.emit_player_derived_stats(events);
             }
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
@@ -153,7 +143,7 @@ pub(crate) fn handle_message(
         }
         GameMessage::PrivateUpdatePropertyString(data) => {
             let update = PropertyUpdate::try_from_raw_string(data.property, data.value.clone());
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
                 updates: vec![update],
@@ -162,7 +152,7 @@ pub(crate) fn handle_message(
         }
         GameMessage::PublicUpdatePropertyString(data) => {
             let update = PropertyUpdate::try_from_raw_string(data.property, data.value.clone());
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
                 updates: vec![update],
@@ -171,7 +161,7 @@ pub(crate) fn handle_message(
         }
         GameMessage::PrivateUpdatePropertyDataId(data) => {
             let update = PropertyUpdate::try_from_raw_did(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
                 updates: vec![update],
@@ -180,7 +170,7 @@ pub(crate) fn handle_message(
         }
         GameMessage::PublicUpdatePropertyDataId(data) => {
             let update = PropertyUpdate::try_from_raw_did(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             events.push(WorldEvent::PropertiesUpdated {
                 guid: target_guid,
                 updates: vec![update],
@@ -190,7 +180,7 @@ pub(crate) fn handle_message(
         GameMessage::PrivateUpdatePropertyInstanceId(data) => {
             let prop = PropertyInstanceId::from_repr(data.property);
             let update = PropertyUpdate::try_from_raw_iid(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             if let Some(prop) = prop {
                 state.apply_instance_id_side_effect(target_guid, prop, data.value, events);
             }
@@ -203,7 +193,7 @@ pub(crate) fn handle_message(
         GameMessage::PublicUpdatePropertyInstanceId(data) => {
             let prop = PropertyInstanceId::from_repr(data.property);
             let update = PropertyUpdate::try_from_raw_iid(data.property, data.value);
-            let target_guid = state.apply_property_update_to_target(data.guid, &update, true);
+            let target_guid = state.apply_property_update_to_target(data.guid, &update);
             if let Some(prop) = prop {
                 state.apply_instance_id_side_effect(target_guid, prop, data.value, events);
             }

--- a/crates/holtburger-world/src/player/mutations.rs
+++ b/crates/holtburger-world/src/player/mutations.rs
@@ -173,14 +173,14 @@ impl PlayerState {
         events: &mut Vec<WorldEvent>,
     ) {
         let old_forced_seq = self.force_position_sequence;
-        let old_grounded = self.server_grounded;
+        let old_grounded = self.last_server_grounded;
 
         self.instance_sequence = pos_pack.instance_sequence;
         self.position_sequence = pos_pack.position_sequence;
         self.teleport_sequence = pos_pack.teleport_sequence;
         self.force_position_sequence = pos_pack.force_position_sequence;
         let is_grounded = pos_pack.flags.contains(UpdatePositionFlag::IS_GROUNDED);
-        self.server_grounded = Some(is_grounded);
+        self.last_server_grounded = Some(is_grounded);
 
         if old_grounded != Some(is_grounded) {
             events.push(WorldEvent::PlayerGroundedUpdated {

--- a/crates/holtburger-world/src/player/mutations.rs
+++ b/crates/holtburger-world/src/player/mutations.rs
@@ -3,7 +3,7 @@ use crate::WorldEvent;
 use crate::player::types::{SkillBase, VitalBase};
 use crate::stats;
 use holtburger_common::Guid;
-use holtburger_common::properties::{EnchantmentTypeFlags, PropertyString};
+use holtburger_common::properties::EnchantmentTypeFlags;
 use holtburger_common::sequence::is_newer_u16;
 use holtburger_protocol::messages::magic::Enchantment;
 use holtburger_protocol::messages::*;
@@ -62,7 +62,6 @@ impl PlayerState {
 
             self.attributes.insert(attr_type, attr_obj.clone());
             events.push(WorldEvent::AttributeUpdated(attr_obj));
-            self.emit_derived_stats(events);
         }
     }
 
@@ -114,7 +113,6 @@ impl PlayerState {
 
             self.skills.insert(skill_type, skill_obj.clone());
             events.push(WorldEvent::SkillUpdated(skill_obj));
-            self.emit_derived_stats(events);
         }
     }
 
@@ -149,7 +147,6 @@ impl PlayerState {
             };
             self.vitals.insert(vital_type, vital_obj.clone());
             events.push(WorldEvent::VitalUpdated(vital_obj));
-            self.emit_derived_stats(events);
         }
     }
 
@@ -178,7 +175,6 @@ impl PlayerState {
         let old_forced_seq = self.force_position_sequence;
         let old_grounded = self.server_grounded;
 
-        self.position = pos_pack.pos;
         self.instance_sequence = pos_pack.instance_sequence;
         self.position_sequence = pos_pack.position_sequence;
         self.teleport_sequence = pos_pack.teleport_sequence;
@@ -195,7 +191,7 @@ impl PlayerState {
         if is_newer_u16(self.force_position_sequence, old_forced_seq) {
             events.push(WorldEvent::ForcedReposition {
                 guid: self.guid,
-                pos: self.position,
+                pos: pos_pack.pos,
                 sequence: self.force_position_sequence,
             });
         }
@@ -306,16 +302,10 @@ impl PlayerState {
         data: &PlayerDescriptionEventData,
         xp_table: &holtburger_dat::file_type::XpTable,
         skill_table: &holtburger_dat::file_type::SkillTable,
-        events: &mut Vec<WorldEvent>,
+        _events: &mut Vec<WorldEvent>,
     ) {
         self.guid = data.guid;
         self.enchantments = data.enchantments.clone();
-        self.properties = data.properties.clone();
-        self.properties
-            .strings
-            .0
-            .entry(PropertyString::Name)
-            .or_insert_with(|| data.name.clone());
 
         self.spells = data.spells.clone();
         self.options1 = data.options1;
@@ -430,8 +420,6 @@ impl PlayerState {
                 self.wield_item(*item_guid, mask);
             }
         }
-
-        self.emit_derived_stats(events);
     }
 
     pub fn upsert_enchantment(
@@ -565,6 +553,5 @@ impl PlayerState {
         events.push(WorldEvent::PlayerEnchantmentsUpdated {
             enchantments: self.enchantments.clone(),
         });
-        self.emit_derived_stats(events);
     }
 }

--- a/crates/holtburger-world/src/player/mutations.rs
+++ b/crates/holtburger-world/src/player/mutations.rs
@@ -165,8 +165,8 @@ impl PlayerState {
         }
     }
 
-    /// Copies a server-authored player position snapshot into player state and emits
-    /// grounded or forced-reposition events when those observable outcomes change.
+    /// Updates the player entity's authoritative position sequencing and cached grounded
+    /// state, then emits grounded or forced-reposition events when those outcomes change.
     pub fn update_position_from_server(
         &mut self,
         pos_pack: &PositionPack,

--- a/crates/holtburger-world/src/player/mutations.rs
+++ b/crates/holtburger-world/src/player/mutations.rs
@@ -431,10 +431,6 @@ impl PlayerState {
             }
         }
 
-        if let Some(pos) = data.pos {
-            self.position = pos;
-        }
-
         self.emit_derived_stats(events);
     }
 

--- a/crates/holtburger-world/src/player/stats_calc.rs
+++ b/crates/holtburger-world/src/player/stats_calc.rs
@@ -1,6 +1,4 @@
 use super::PlayerState;
-use crate::WorldEvent;
-use crate::player::types::LastSentStats;
 use crate::stats;
 use holtburger_common::properties::EnchantmentTypeFlags;
 
@@ -192,7 +190,7 @@ impl PlayerState {
         }
     }
 
-    pub fn emit_derived_stats(&mut self, events: &mut Vec<WorldEvent>) {
+    pub(crate) fn refresh_cached_derived_stat_inputs(&mut self) {
         // Recalculate Attributes
         let attr_types: Vec<_> = self.attributes.keys().cloned().collect();
         for attr_type in attr_types {
@@ -233,40 +231,5 @@ impl PlayerState {
                 skill.current = current_val;
             }
         }
-
-        // Recalculate Armor
-        let armor = self.armor();
-
-        // Recalculate Resistances
-        let resistances = self.resistances();
-
-        // Recalculate Vitae
-        let vitae = self.vitae();
-
-        let current = LastSentStats {
-            attributes: self.get_attributes(),
-            vitals: self.get_vitals(),
-            skills: self.get_skills(),
-            resistances: resistances.clone(),
-            armor,
-            vitae,
-        };
-
-        if self.last_sent_stats.as_ref() == Some(&current) {
-            return;
-        }
-
-        self.last_sent_stats = Some(current.clone());
-
-        events.push(WorldEvent::DerivedStatsUpdated(Box::new(
-            crate::DerivedStatsData {
-                attributes: current.attributes,
-                vitals: current.vitals,
-                skills: current.skills,
-                resistances: current.resistances,
-                armor: current.armor,
-                vitae: current.vitae,
-            },
-        )));
     }
 }

--- a/crates/holtburger-world/src/player/tests.rs
+++ b/crates/holtburger-world/src/player/tests.rs
@@ -78,14 +78,24 @@ fn test_stat_calculations() {
 
 #[test]
 fn test_resistance_derivation_matches_ace_player_rules() {
-    let mut player = PlayerState::new();
+    let mut state = WorldState::synthetic();
+    let player_guid = Guid(0x50000001);
+    state.seed_local_player_entity(player_guid, "Player", WorldPosition::default());
 
-    set_attr(&mut player, stats::AttributeType::StrengthAttr, 200);
-    set_attr(&mut player, stats::AttributeType::EnduranceAttr, 200);
-    player.set_float_prop(PropertyFloat::ResistFire, 1.0);
-    player.set_int_prop(PropertyInt::AugmentationResistanceFire, 1);
+    set_attr(&mut state.player, stats::AttributeType::StrengthAttr, 200);
+    set_attr(&mut state.player, stats::AttributeType::EnduranceAttr, 200);
+    state
+        .player_entity_mut()
+        .expect("local player entity should exist")
+        .properties
+        .set_float_prop(PropertyFloat::ResistFire, 1.0);
+    state
+        .player_entity_mut()
+        .expect("local player entity should exist")
+        .properties
+        .set_int_prop(PropertyInt::AugmentationResistanceFire, 1);
 
-    player.enchantments.push(Enchantment {
+    state.player.enchantments.push(Enchantment {
         spell_category: 10,
         power_level: 100,
         stat_mod_type: (EnchantmentTypeFlags::FLOAT
@@ -97,7 +107,7 @@ fn test_resistance_derivation_matches_ace_player_rules() {
         ..Default::default()
     });
 
-    player.enchantments.push(Enchantment {
+    state.player.enchantments.push(Enchantment {
         spell_category: 20,
         power_level: 100,
         stat_mod_type: (EnchantmentTypeFlags::FLOAT
@@ -109,7 +119,7 @@ fn test_resistance_derivation_matches_ace_player_rules() {
         ..Default::default()
     });
 
-    player.enchantments.push(Enchantment {
+    state.player.enchantments.push(Enchantment {
         spell_category: 30,
         power_level: 100,
         stat_mod_type: (EnchantmentTypeFlags::FLOAT
@@ -121,7 +131,7 @@ fn test_resistance_derivation_matches_ace_player_rules() {
         ..Default::default()
     });
 
-    let resistance = player.get_resistance_current(PropertyFloat::ResistFire);
+    let resistance = state.player_resistance_current(PropertyFloat::ResistFire);
 
     assert!((resistance - 0.72).abs() < 0.0001);
 }
@@ -276,8 +286,15 @@ fn test_stat_floors() {
     );
 
     // 4. Armor level check (can stay negative for Armor Self / Imperil logic)
-    player.set_int_prop(PropertyInt::ArmorLevel, 10);
-    player.enchantments.push(Enchantment {
+    let mut state = WorldState::synthetic();
+    let player_guid = Guid(0x50000001);
+    state.seed_local_player_entity(player_guid, "Player", WorldPosition::default());
+    state
+        .player_entity_mut()
+        .expect("local player entity should exist")
+        .properties
+        .set_int_prop(PropertyInt::ArmorLevel, 10);
+    state.player.enchantments.push(Enchantment {
         spell_id: 5,
         layer: 1,
         spell_category: 5,
@@ -295,9 +312,9 @@ fn test_stat_floors() {
         stat_mod_value: -20.0,
         spell_set_id: None,
     });
-    player.emit_derived_stats(&mut Vec::new());
+    state.emit_player_derived_stats(&mut Vec::new());
     // 10 - 20 = -10.
-    assert_eq!(player.armor(), -10);
+    assert_eq!(state.player_armor(), -10);
 }
 
 #[test]
@@ -521,7 +538,7 @@ fn test_magic_purge_bad_enchantments_preserves_vitae() {
     assert!(state.player.enchantments.iter().any(|e| e.spell_id == 100));
     assert!(!state.player.enchantments.iter().any(|e| e.spell_id == 200));
     assert!(state.player.enchantments.iter().any(|e| e.spell_id == 300));
-    assert_eq!(state.player.vitae(), 0.95);
+    assert_eq!(state.player_vitae(), 0.95);
 
     assert!(
         events
@@ -857,8 +874,7 @@ fn test_vector_update_applies_self_velocity_and_omega() {
     state.player.guid = Guid(0x50000001);
 
     let start = WorldPosition::default();
-    state.player.position = start;
-    state.add_entity(Entity::new(state.player.guid, "Player".to_string(), start));
+    state.seed_local_player_entity(state.player.guid, "Player", start);
 
     let msg = GameMessage::VectorUpdate(Box::new(VectorUpdateData {
         guid: state.player.guid,
@@ -956,7 +972,7 @@ fn test_magic_purge_enchantments_preserves_vitae_only() {
 
     assert!(!state.player.enchantments.iter().any(|e| e.spell_id == 100));
     assert!(state.player.enchantments.iter().any(|e| e.spell_id == 666));
-    assert_eq!(state.player.vitae(), 0.88);
+    assert_eq!(state.player_vitae(), 0.88);
 
     let latest_derived_vitae = events.iter().rev().find_map(|e| match e {
         WorldEvent::DerivedStatsUpdated(data) => Some(data.vitae),
@@ -1015,15 +1031,9 @@ fn test_stale_update_position_is_ignored_when_teleport_sequence_regresses() {
 
     let mut player = PlayerState::new();
     player.guid = Guid(0x50000001);
-    player.position = WorldPosition {
-        landblock_id: Guid(0x01000000),
-        coords: Vector3::new(1.0, 2.0, 3.0),
-        ..Default::default()
-    };
     player.teleport_sequence = 10;
     player.force_position_sequence = 4;
 
-    let original_position = player.position;
     let mut events = Vec::<WorldEvent>::new();
     let applied = player.apply_position_from_server(
         &PositionPack {
@@ -1043,7 +1053,8 @@ fn test_stale_update_position_is_ignored_when_teleport_sequence_regresses() {
     );
 
     assert!(!applied);
-    assert_eq!(player.position, original_position);
+    assert_eq!(player.teleport_sequence, 10);
+    assert_eq!(player.force_position_sequence, 4);
     assert!(events.is_empty());
 }
 
@@ -1056,15 +1067,9 @@ fn test_stale_update_position_is_ignored_when_force_sequence_regresses() {
 
     let mut player = PlayerState::new();
     player.guid = Guid(0x50000001);
-    player.position = WorldPosition {
-        landblock_id: Guid(0x01000000),
-        coords: Vector3::new(1.0, 2.0, 3.0),
-        ..Default::default()
-    };
     player.teleport_sequence = 10;
     player.force_position_sequence = 7;
 
-    let original_position = player.position;
     let mut events = Vec::<WorldEvent>::new();
     let applied = player.apply_position_from_server(
         &PositionPack {
@@ -1084,7 +1089,8 @@ fn test_stale_update_position_is_ignored_when_force_sequence_regresses() {
     );
 
     assert!(!applied);
-    assert_eq!(player.position, original_position);
+    assert_eq!(player.teleport_sequence, 10);
+    assert_eq!(player.force_position_sequence, 7);
     assert!(events.is_empty());
 }
 

--- a/crates/holtburger-world/src/player/tests.rs
+++ b/crates/holtburger-world/src/player/tests.rs
@@ -1005,7 +1005,7 @@ fn test_update_position_from_server_caches_grounded_state() {
         },
         &mut events,
     );
-    assert_eq!(player.server_grounded, Some(false));
+    assert_eq!(player.last_server_grounded, Some(false));
 
     player.update_position_from_server(
         &PositionPack {
@@ -1019,7 +1019,7 @@ fn test_update_position_from_server_caches_grounded_state() {
         },
         &mut events,
     );
-    assert_eq!(player.server_grounded, Some(true));
+    assert_eq!(player.last_server_grounded, Some(true));
 }
 
 #[test]

--- a/crates/holtburger-world/src/player/types.rs
+++ b/crates/holtburger-world/src/player/types.rs
@@ -1,12 +1,6 @@
 use crate::stats;
-use holtburger_common::position::WorldPosition;
-use holtburger_common::properties::{
-    HasProperties, HasPropertiesMut, PropertyFloat, PropertyInt, PropertyInt64, PropertyString,
-    PropertyUpdate, WorldObjectProperties, WorldObjectPropertyAccessors,
-};
 use holtburger_common::{CharacterOption, CharacterOptions1, CharacterOptions2, Guid};
 use holtburger_protocol::messages::EquipMask;
-use holtburger_protocol::messages::combat::CombatMode;
 use holtburger_protocol::messages::magic::Enchantment;
 use holtburger_protocol::messages::movement::{MotionStance, PositionType};
 use serde::{Deserialize, Serialize};
@@ -214,9 +208,6 @@ fn character_option_mask(option: CharacterOption) -> CharacterOptionMask {
 /// handlers under `crate::handlers` orchestrate message flows and call into focused mutation
 /// methods on `PlayerState` and `WorldState`.
 ///
-/// NOTE: physical player location/velocity is mirrored in `WorldState.entities`. Mutations that
-/// affect the mirrored physical state should go through `WorldState` helper methods so the entity
-/// graph and spatial index stay in sync.
 #[derive(Debug, Clone)]
 pub struct PlayerState {
     /// Unique identifier for the player's character.
@@ -231,8 +222,6 @@ pub struct PlayerState {
     pub skills: HashMap<stats::SkillType, stats::Skill>,
     /// Stores the raw ranks and init for skills so they can be recalculated during stat updates.
     pub skill_bases: HashMap<stats::SkillType, SkillBase>,
-    /// Current position in the world (Landcell + local coordinates).
-    pub position: WorldPosition,
     /// Sequence for object instantiation/removal.
     pub instance_sequence: u16,
     /// Sequence for server-controlled movement/actions.
@@ -250,7 +239,7 @@ pub struct PlayerState {
     /// Monotonically increasing sequence for autonomous movement steps.
     pub movement_sequence: u16,
     /// Sparse authoritative storage for non-live position properties keyed by packet `PositionType`.
-    pub position_properties: HashMap<PositionType, WorldPosition>,
+    pub position_properties: HashMap<PositionType, holtburger_common::position::WorldPosition>,
     /// List of all active enchantments (buffs/debuffs) currently affecting the player.
     pub enchantments: Vec<Enchantment>,
     /// Master list of known spells (Knowledge). Maps SpellID -> Power/Modifier level.
@@ -267,9 +256,6 @@ pub struct PlayerState {
     pub spellbook_filters: u32,
     /// Opaque gameplay options blob retained from PlayerDescription.
     pub gameplay_options: Vec<u8>,
-    /// All server-sent properties for the player.
-    pub properties: WorldObjectProperties,
-
     /// Whether collision detection is disabled for movement.
     pub noclip: bool,
 
@@ -297,7 +283,6 @@ impl PlayerState {
             vital_bases: HashMap::new(),
             skills: HashMap::new(),
             skill_bases: HashMap::new(),
-            position: WorldPosition::default(),
             instance_sequence: 0,
             server_control_sequence: 0,
             last_server_motion_style: None,
@@ -315,7 +300,6 @@ impl PlayerState {
             desired_comps: Vec::new(),
             spellbook_filters: 0,
             gameplay_options: Vec::new(),
-            properties: WorldObjectProperties::default(),
             noclip: false,
             inventory: HashSet::new(),
             equipment: HashMap::new(),
@@ -323,126 +307,27 @@ impl PlayerState {
         }
     }
 
-    pub fn level(&self) -> u32 {
-        self.get_int_prop_default(PropertyInt::Level) as u32
-    }
-
-    pub fn total_experience(&self) -> u64 {
-        self.get_int64_prop(PropertyInt64::TotalExperience)
-            .unwrap_or(0) as u64
-    }
-
-    pub fn available_experience(&self) -> u64 {
-        self.get_int64_prop(PropertyInt64::AvailableExperience)
-            .unwrap_or(0) as u64
-    }
-
-    pub fn unspent_skill_points(&self) -> u32 {
-        self.get_int_prop_default(PropertyInt::AvailableSkillCredits) as u32
-    }
-
-    pub fn available_luminance(&self) -> u64 {
-        self.get_int64_prop(PropertyInt64::AvailableLuminance)
-            .unwrap_or(0) as u64
-    }
-
-    pub fn combat_mode(&self) -> CombatMode {
-        let val = self.get_int_prop_default(PropertyInt::CombatMode);
-        CombatMode::from_repr(val as u32).unwrap_or(CombatMode::NonCombat)
-    }
-
-    pub fn name(&self) -> &str {
-        self.get_string_prop(PropertyString::Name)
-            .unwrap_or("Unknown")
-    }
-
-    pub fn armor(&self) -> i32 {
-        let base_armor = self.get_int_prop_default(PropertyInt::ArmorLevel);
-        i32::max(
-            -400,
-            crate::magic::get_enchanted_armor(base_armor, &self.enchantments),
-        )
-    }
-
     pub fn vitae(&self) -> f32 {
         crate::magic::get_total_vitae(&self.enchantments)
     }
 
-    pub fn position_property(&self, position_type: PositionType) -> Option<WorldPosition> {
+    pub fn position_property(
+        &self,
+        position_type: PositionType,
+    ) -> Option<holtburger_common::position::WorldPosition> {
         self.position_properties.get(&position_type).copied()
     }
 
-    pub fn set_position_property(&mut self, position_type: PositionType, position: WorldPosition) {
+    pub fn set_position_property(
+        &mut self,
+        position_type: PositionType,
+        position: holtburger_common::position::WorldPosition,
+    ) {
         self.position_properties.insert(position_type, position);
-    }
-
-    pub(crate) fn get_resistance_augmentation(&self, prop: PropertyFloat) -> i32 {
-        let augmentation_prop = match prop {
-            PropertyFloat::ResistSlash => PropertyInt::AugmentationResistanceSlash,
-            PropertyFloat::ResistPierce => PropertyInt::AugmentationResistancePierce,
-            PropertyFloat::ResistBludgeon => PropertyInt::AugmentationResistanceBlunt,
-            PropertyFloat::ResistFire => PropertyInt::AugmentationResistanceFire,
-            PropertyFloat::ResistCold => PropertyInt::AugmentationResistanceFrost,
-            PropertyFloat::ResistAcid => PropertyInt::AugmentationResistanceAcid,
-            PropertyFloat::ResistElectric => PropertyInt::AugmentationResistanceLightning,
-            PropertyFloat::ResistNether => PropertyInt::AugmentationResistanceNether,
-            _ => return 0,
-        };
-
-        self.get_int_prop(augmentation_prop).unwrap_or(0)
-    }
-
-    pub fn get_resistance_current(&self, prop: PropertyFloat) -> f32 {
-        let base = self.get_float_prop(prop).unwrap_or(1.0) as f32;
-        let strength_base = self.get_attribute_base(stats::AttributeType::StrengthAttr);
-        let endurance_base = self.get_attribute_base(stats::AttributeType::EnduranceAttr);
-        let augmentation_resistance = self.get_resistance_augmentation(prop);
-
-        crate::magic::get_player_enchanted_resistance(
-            base,
-            &self.enchantments,
-            prop as u32,
-            strength_base,
-            endurance_base,
-            augmentation_resistance,
-        )
-    }
-
-    pub fn resistances(&self) -> stats::Resistances {
-        stats::Resistances {
-            slash: self.get_resistance_current(PropertyFloat::ResistSlash),
-            pierce: self.get_resistance_current(PropertyFloat::ResistPierce),
-            bludgeon: self.get_resistance_current(PropertyFloat::ResistBludgeon),
-            fire: self.get_resistance_current(PropertyFloat::ResistFire),
-            cold: self.get_resistance_current(PropertyFloat::ResistCold),
-            acid: self.get_resistance_current(PropertyFloat::ResistAcid),
-            electric: self.get_resistance_current(PropertyFloat::ResistElectric),
-            nether: self.get_resistance_current(PropertyFloat::ResistNether),
-        }
-    }
-}
-
-impl HasProperties for PlayerState {
-    fn properties(&self) -> &WorldObjectProperties {
-        &self.properties
-    }
-}
-
-impl HasPropertiesMut for PlayerState {
-    fn properties_mut(&mut self) -> &mut WorldObjectProperties {
-        &mut self.properties
     }
 }
 
 impl PlayerState {
-    pub fn get_int_prop_default(&self, prop: PropertyInt) -> i32 {
-        self.get_int_prop(prop).unwrap_or(0)
-    }
-
-    pub fn set_property(&mut self, update: PropertyUpdate) {
-        self.properties.apply(update);
-    }
-
     /// Adds an item to the player's inventory tracking.
     pub fn add_to_inventory(&mut self, item: Guid) {
         self.inventory.insert(item);

--- a/crates/holtburger-world/src/player/types.rs
+++ b/crates/holtburger-world/src/player/types.rs
@@ -204,9 +204,10 @@ fn character_option_mask(option: CharacterOption) -> CharacterOptionMask {
 /// Session-local player model and derived player-facing state.
 ///
 /// `PlayerState` owns player-specific data such as attributes, vitals, spells, inventory, and
-/// protocol sequence tracking. It is intentionally **not** the protocol router anymore; feature
-/// handlers under `crate::handlers` orchestrate message flows and call into focused mutation
-/// methods on `PlayerState` and `WorldState`.
+/// protocol sequence tracking. It is intentionally **not** a second world object: authoritative
+/// entity/object state lives on the player `Entity`, while `PlayerState` retains only local-player
+/// overlays and session sequencing. Feature handlers under `crate::handlers` orchestrate message
+/// flows and call into focused mutation methods on `PlayerState` and `WorldState`.
 ///
 #[derive(Debug, Clone)]
 pub struct PlayerState {
@@ -234,12 +235,12 @@ pub struct PlayerState {
     pub force_position_sequence: u16,
     /// Sequence for client-initiated position updates.
     pub position_sequence: u16,
-    /// Last grounded state reported by authoritative server movement updates.
-    pub server_grounded: Option<bool>,
+    /// Last grounded bit reported by authoritative self movement updates.
+    pub last_server_grounded: Option<bool>,
     /// Monotonically increasing sequence for autonomous movement steps.
     pub movement_sequence: u16,
-    /// Sparse authoritative storage for non-live position properties keyed by packet `PositionType`.
-    pub position_properties: HashMap<PositionType, holtburger_common::position::WorldPosition>,
+    /// Session-local private position overlays keyed by packet `PositionType`.
+    pub local_position_overlays: HashMap<PositionType, holtburger_common::position::WorldPosition>,
     /// List of all active enchantments (buffs/debuffs) currently affecting the player.
     pub enchantments: Vec<Enchantment>,
     /// Master list of known spells (Knowledge). Maps SpellID -> Power/Modifier level.
@@ -264,8 +265,8 @@ pub struct PlayerState {
     /// Items currently equipped, mapped by their primary slot mask.
     pub equipment: HashMap<Guid, EquipMask>,
 
-    /// Dirty tracking for events to minimize redundant UI updates.
-    pub(crate) last_sent_stats: Option<LastSentStats>,
+    /// Dirty tracking for emitted derived-stat snapshots.
+    pub(crate) last_emitted_derived_stats: Option<LastSentStats>,
 }
 
 impl Default for PlayerState {
@@ -289,9 +290,9 @@ impl PlayerState {
             teleport_sequence: 0,
             force_position_sequence: 0,
             position_sequence: 0,
-            server_grounded: None,
+            last_server_grounded: None,
             movement_sequence: 0,
-            position_properties: HashMap::new(),
+            local_position_overlays: HashMap::new(),
             enchantments: Vec::new(),
             spells: BTreeMap::new(),
             options1: CharacterOptions1::empty(),
@@ -303,7 +304,7 @@ impl PlayerState {
             noclip: false,
             inventory: HashSet::new(),
             equipment: HashMap::new(),
-            last_sent_stats: None,
+            last_emitted_derived_stats: None,
         }
     }
 
@@ -311,19 +312,19 @@ impl PlayerState {
         crate::magic::get_total_vitae(&self.enchantments)
     }
 
-    pub fn position_property(
+    pub fn local_position_overlay(
         &self,
         position_type: PositionType,
     ) -> Option<holtburger_common::position::WorldPosition> {
-        self.position_properties.get(&position_type).copied()
+        self.local_position_overlays.get(&position_type).copied()
     }
 
-    pub fn set_position_property(
+    pub fn set_local_position_overlay(
         &mut self,
         position_type: PositionType,
         position: holtburger_common::position::WorldPosition,
     ) {
-        self.position_properties.insert(position_type, position);
+        self.local_position_overlays.insert(position_type, position);
     }
 }
 
@@ -350,19 +351,19 @@ impl PlayerState {
         self.equipment.remove(&item);
     }
 
-    pub fn get_attributes(&self) -> Vec<stats::Attribute> {
+    pub fn attribute_snapshot(&self) -> Vec<stats::Attribute> {
         let mut attr_objs: Vec<_> = self.attributes.values().cloned().collect();
         attr_objs.sort_by_key(|a| a.attr_type as u32);
         attr_objs
     }
 
-    pub fn get_vitals(&self) -> Vec<stats::Vital> {
+    pub fn vital_snapshot(&self) -> Vec<stats::Vital> {
         let mut vitals: Vec<_> = self.vitals.values().cloned().collect();
         vitals.sort_by_key(|v| v.vital_type as u32);
         vitals
     }
 
-    pub fn get_skills(&self) -> Vec<stats::Skill> {
+    pub fn skill_snapshot(&self) -> Vec<stats::Skill> {
         let mut skills: Vec<_> = self.skills.values().cloned().collect();
         skills.sort_by_key(|s| s.skill_type as u32);
         skills

--- a/crates/holtburger-world/src/state/liveness.rs
+++ b/crates/holtburger-world/src/state/liveness.rs
@@ -148,11 +148,9 @@ impl WorldState {
         nearby_guids: &HashSet<Guid>,
     ) -> bool {
         nearby_guids.contains(&entity.guid)
-            || self
-                .player_position()
-                .is_some_and(|position| position.distance_to(&entity.position)
-                <= CONSERVATIVE_VISIBILITY_DISTANCE_M
-                )
+            || self.player_position().is_some_and(|position| {
+                position.distance_to(&entity.position) <= CONSERVATIVE_VISIBILITY_DISTANCE_M
+            })
     }
 
     fn maintain_visibility_prune_deadlines(&mut self, now: f64) {

--- a/crates/holtburger-world/src/state/liveness.rs
+++ b/crates/holtburger-world/src/state/liveness.rs
@@ -118,10 +118,9 @@ impl WorldState {
             return HashSet::new();
         }
 
-        let player_landblock = self.player.position.landblock_id;
-        if player_landblock == Guid::NULL {
+        let Some(player_landblock) = self.player_landblock() else {
             return HashSet::new();
-        }
+        };
 
         let nearby_guids = self.scene.get_nearby_entities(player_landblock);
 
@@ -149,8 +148,11 @@ impl WorldState {
         nearby_guids: &HashSet<Guid>,
     ) -> bool {
         nearby_guids.contains(&entity.guid)
-            || self.player.position.distance_to(&entity.position)
+            || self
+                .player_position()
+                .is_some_and(|position| position.distance_to(&entity.position)
                 <= CONSERVATIVE_VISIBILITY_DISTANCE_M
+                )
     }
 
     fn maintain_visibility_prune_deadlines(&mut self, now: f64) {
@@ -364,7 +366,9 @@ impl WorldState {
             return Vec::new();
         }
 
-        let lb = self.player.position.landblock_id;
+        let Some(lb) = self.player_landblock() else {
+            return Vec::new();
+        };
 
         let nearby_guids = self.scene.get_nearby_entities(lb);
         nearby_guids

--- a/crates/holtburger-world/src/state/mutations.rs
+++ b/crates/holtburger-world/src/state/mutations.rs
@@ -278,11 +278,11 @@ impl WorldState {
             return;
         };
 
-        if self.player.server_grounded == Some(grounded) {
+        if self.player.last_server_grounded == Some(grounded) {
             return;
         }
 
-        self.player.server_grounded = Some(grounded);
+        self.player.last_server_grounded = Some(grounded);
         events.push(WorldEvent::PlayerGroundedUpdated { grounded });
     }
 
@@ -388,24 +388,16 @@ impl WorldState {
         events.push(WorldEvent::LevelInfoUpdated(self.get_level_info()));
     }
 
-    pub(crate) fn emit_player_info(
-        &self,
-        guid: Guid,
-        name: String,
-        pos: Option<WorldPosition>,
-        events: &mut Vec<WorldEvent>,
-    ) {
+    pub(crate) fn emit_player_info(&self, events: &mut Vec<WorldEvent>) {
+        let Some(entity) = self.player_entity() else {
+            return;
+        };
+
         events.push(WorldEvent::PlayerInfo(Box::new(crate::PlayerInfoData {
-            guid,
-            name,
-            pos,
-            player_entity: self
-                .entities
-                .get(guid)
-                .map(|entity| Box::new(entity.clone())),
-            attributes: self.player.get_attributes(),
-            vitals: self.player.get_vitals(),
-            skills: self.player.get_skills(),
+            entity: Box::new(entity.clone()),
+            attributes: self.player.attribute_snapshot(),
+            vitals: self.player.vital_snapshot(),
+            skills: self.player.skill_snapshot(),
             enchantments: self.player.enchantments.clone(),
             spells: self.player.spells.keys().cloned().collect(),
             level_info: self.get_level_info(),
@@ -457,9 +449,9 @@ impl WorldState {
         data: &PlayerDescriptionEventData,
         events: &mut Vec<WorldEvent>,
     ) {
-        let pos = self.bootstrap_player_entity_from_description(data);
+        self.bootstrap_player_entity_from_description(data);
 
-        self.emit_player_info(data.guid, data.name.clone(), pos, events);
+        self.emit_player_info(events);
         self.emit_level_info(events);
     }
 
@@ -561,7 +553,8 @@ impl WorldState {
             return;
         }
 
-        self.player.set_position_property(position_type, position);
+        self.player
+            .set_local_position_overlay(position_type, position);
     }
 
     /// Updates the player's authoritative entity position and keeps the SpatialScene
@@ -740,7 +733,8 @@ impl WorldState {
         }
 
         if guid == self.player.guid {
-            self.player.set_position_property(position_type, position);
+            self.player
+                .set_local_position_overlay(position_type, position);
         }
 
         true

--- a/crates/holtburger-world/src/state/mutations.rs
+++ b/crates/holtburger-world/src/state/mutations.rs
@@ -73,7 +73,7 @@ impl WorldState {
         }
 
         if guid == self.player.guid {
-            Some(self.player.position)
+            self.player_position()
         } else {
             self.entities.get(guid).map(|entity| entity.position)
         }
@@ -89,12 +89,12 @@ impl WorldState {
         }
 
         if guid == self.player.guid {
-            let (velocity, omega) = self
-                .entities
-                .get(guid)
-                .map(|entity| (entity.velocity, entity.omega))
-                .unwrap_or((Vector3::zero(), Vector3::zero()));
-            Some((body_id, self.player.position, velocity, omega))
+            self.player_entity()
+                .map(|entity| (body_id, entity.position, entity.velocity, entity.omega))
+                .or_else(|| {
+                    self.player_position()
+                        .map(|position| (body_id, position, Vector3::zero(), Vector3::zero()))
+                })
         } else {
             self.entities
                 .get(guid)
@@ -126,15 +126,15 @@ impl WorldState {
 
         let guid = body_id.authoritative_guid()?;
         if matches!(body_id, SpatialBodyId::LocalPlayer(_)) {
+            let authoritative_pose = self.player_position()?;
             let (velocity, omega, motion_state) = self
-                .entities
-                .get(guid)
+                .player_entity()
                 .map(|entity| (entity.velocity, entity.omega, entity.motion_snapshot))
                 .unwrap_or((Vector3::zero(), Vector3::zero(), None));
             return Some(RuntimeSpatialBodyView {
                 body_id,
-                authoritative_pose: Some(self.player.position),
-                runtime_pose: self.player.position,
+                authoritative_pose: Some(authoritative_pose),
+                runtime_pose: authoritative_pose,
                 velocity,
                 omega,
                 motion_state,
@@ -448,22 +448,49 @@ impl WorldState {
         })));
     }
 
+    fn bootstrap_player_entity_from_description(
+        &mut self,
+        data: &PlayerDescriptionEventData,
+    ) -> Option<WorldPosition> {
+        let guid = data.guid;
+        let mut properties = data.properties.clone();
+        properties
+            .strings
+            .0
+            .entry(PropertyString::Name)
+            .or_insert_with(|| data.name.clone());
+
+        let bootstrap_position = data
+            .pos
+            .or_else(|| self.entities.get(guid).map(|entity| entity.position))
+            .or_else(|| (guid == self.player.guid).then_some(self.player.position))
+            .unwrap_or_default();
+
+        if let Some(entity) = self.entities.get_mut(guid) {
+            entity.properties = properties;
+            entity.position = bootstrap_position;
+            entity.set_string_prop(PropertyString::Name, data.name.clone());
+        } else {
+            let mut entity = crate::entity::Entity::new(guid, data.name.clone(), bootstrap_position);
+            entity.properties = properties;
+            self.add_entity(entity);
+        }
+
+        if data.pos.is_some() {
+            self.sync_player_position(bootstrap_position);
+        }
+
+        self.entities.get(guid).map(|entity| entity.position)
+    }
+
     pub(crate) fn apply_player_description_world_state(
         &mut self,
-        guid: Guid,
-        name: &str,
-        pos: Option<WorldPosition>,
+        data: &PlayerDescriptionEventData,
         events: &mut Vec<WorldEvent>,
     ) {
-        if let Some(entity) = self.entities.get_mut(guid) {
-            entity.set_string_prop(PropertyString::Name, name.to_string());
-        }
+        let pos = self.bootstrap_player_entity_from_description(data);
 
-        if let Some(position) = pos {
-            events.extend(self.set_player_position(position));
-        }
-
-        self.emit_player_info(guid, name.to_string(), pos, events);
+        self.emit_player_info(data.guid, data.name.clone(), pos, events);
         self.emit_level_info(events);
     }
 
@@ -585,13 +612,16 @@ impl WorldState {
             || !pos.rotation.y.is_finite()
             || !pos.rotation.z.is_finite()
         {
-            pos.rotation = self.player.position.rotation;
+            pos.rotation = self
+                .player_position()
+                .map(|current| current.rotation)
+                .unwrap_or_default();
         }
 
-        let old_lb = self.player.position.landblock_id;
+        let old_lb = self.player_landblock().unwrap_or(Guid::NULL);
         self.player.position = pos;
 
-        if let Some(entity) = self.entities.get_mut(guid) {
+        if let Some(entity) = self.player_entity_mut() {
             entity.position = pos;
         }
         self.scene.update_entity(guid, old_lb, pos);
@@ -671,7 +701,10 @@ impl WorldState {
         let runtime_delta_m = self
             .local_player_runtime_pose()
             .map(|pose| pose.distance_to(&data.position));
-        let auth_delta_m = self.player.position.distance_to(&data.position);
+        let auth_delta_m = self
+            .player_position()
+            .map(|position| position.distance_to(&data.position))
+            .unwrap_or_default();
 
         log::debug!(
             "player: self AutonomousPosition {} pos {:?} runtime_delta={:?} auth_delta={:.2}m seqs inst={} server={} teleport={} force={} current teleport={} force={} server={}",

--- a/crates/holtburger-world/src/state/mutations.rs
+++ b/crates/holtburger-world/src/state/mutations.rs
@@ -1076,10 +1076,8 @@ impl WorldState {
                 physics_state: data.physics_state,
             });
             true
-        } else if data.guid == self.player.guid {
-            true
         } else {
-            false
+            data.guid == self.player.guid
         }
     }
 

--- a/crates/holtburger-world/src/state/mutations.rs
+++ b/crates/holtburger-world/src/state/mutations.rs
@@ -72,11 +72,7 @@ impl WorldState {
             return Some(body.pose);
         }
 
-        if guid == self.player.guid {
-            self.player_position()
-        } else {
-            self.entities.get(guid).map(|entity| entity.position)
-        }
+        self.entities.get(guid).map(|entity| entity.position)
     }
 
     pub fn runtime_kinematics_for_guid(
@@ -88,18 +84,9 @@ impl WorldState {
             return Some((body_id, body.pose, body.velocity, body.omega));
         }
 
-        if guid == self.player.guid {
-            self.player_entity()
-                .map(|entity| (body_id, entity.position, entity.velocity, entity.omega))
-                .or_else(|| {
-                    self.player_position()
-                        .map(|position| (body_id, position, Vector3::zero(), Vector3::zero()))
-                })
-        } else {
-            self.entities
-                .get(guid)
-                .map(|entity| (body_id, entity.position, entity.velocity, entity.omega))
-        }
+        self.entities
+            .get(guid)
+            .map(|entity| (body_id, entity.position, entity.velocity, entity.omega))
     }
 
     pub fn local_player_runtime_pose(&self) -> Option<WorldPosition> {
@@ -125,24 +112,6 @@ impl WorldState {
         }
 
         let guid = body_id.authoritative_guid()?;
-        if matches!(body_id, SpatialBodyId::LocalPlayer(_)) {
-            let authoritative_pose = self.player_position()?;
-            let (velocity, omega, motion_state) = self
-                .player_entity()
-                .map(|entity| (entity.velocity, entity.omega, entity.motion_snapshot))
-                .unwrap_or((Vector3::zero(), Vector3::zero(), None));
-            return Some(RuntimeSpatialBodyView {
-                body_id,
-                authoritative_pose: Some(authoritative_pose),
-                runtime_pose: authoritative_pose,
-                velocity,
-                omega,
-                motion_state,
-                contact: ContactState::Unknown,
-                sample_mode: SpatialSampleMode::AuthoritativeOnly,
-            });
-        }
-
         self.entities
             .get(guid)
             .map(|entity| RuntimeSpatialBodyView {
@@ -440,9 +409,9 @@ impl WorldState {
             enchantments: self.player.enchantments.clone(),
             spells: self.player.spells.keys().cloned().collect(),
             level_info: self.get_level_info(),
-            resistances: self.player.resistances(),
-            armor: self.player.armor(),
-            vitae: self.player.vitae(),
+            resistances: self.player_resistances(),
+            armor: self.player_armor(),
+            vitae: self.player_vitae(),
             inventory: self.player.inventory.clone(),
             equipment: self.player.equipment.clone(),
         })));
@@ -463,7 +432,6 @@ impl WorldState {
         let bootstrap_position = data
             .pos
             .or_else(|| self.entities.get(guid).map(|entity| entity.position))
-            .or_else(|| (guid == self.player.guid).then_some(self.player.position))
             .unwrap_or_default();
 
         if let Some(entity) = self.entities.get_mut(guid) {
@@ -471,7 +439,8 @@ impl WorldState {
             entity.position = bootstrap_position;
             entity.set_string_prop(PropertyString::Name, data.name.clone());
         } else {
-            let mut entity = crate::entity::Entity::new(guid, data.name.clone(), bootstrap_position);
+            let mut entity =
+                crate::entity::Entity::new(guid, data.name.clone(), bootstrap_position);
             entity.properties = properties;
             self.add_entity(entity);
         }
@@ -595,8 +564,8 @@ impl WorldState {
         self.player.set_position_property(position_type, position);
     }
 
-    /// Updates the player's position, ensuring the record in PlayerState,
-    /// the mirrored Entity, and the SpatialScene stay in sync.
+    /// Updates the player's authoritative entity position and keeps the SpatialScene
+    /// reconciliation state aligned with that world-owned pose.
     fn update_player_position(
         &mut self,
         mut pos: WorldPosition,
@@ -619,10 +588,10 @@ impl WorldState {
         }
 
         let old_lb = self.player_landblock().unwrap_or(Guid::NULL);
-        self.player.position = pos;
-
         if let Some(entity) = self.player_entity_mut() {
             entity.position = pos;
+        } else {
+            return None;
         }
         self.scene.update_entity(guid, old_lb, pos);
         let (velocity, omega) = self
@@ -649,7 +618,7 @@ impl WorldState {
         events
     }
 
-    /// Synchronizes the player's mirrored position without emitting movement events.
+    /// Synchronizes the authoritative player position without emitting movement events.
     ///
     /// This is intended for hydration/bootstrap flows where the client is seeding authoritative
     /// state rather than reacting to a live movement update packet.
@@ -1029,7 +998,6 @@ impl WorldState {
         &mut self,
         guid: Guid,
         update: &PropertyUpdate,
-        mirror_player: bool,
     ) -> Guid {
         let target_guid = self.resolve_property_target_guid(guid);
 
@@ -1042,10 +1010,6 @@ impl WorldState {
                 .find(|item| item.guid == target_guid)
         {
             item.set_property(update.clone());
-        }
-
-        if mirror_player && target_guid == self.player.guid {
-            self.player.set_property(update.clone());
         }
 
         target_guid
@@ -1108,7 +1072,6 @@ impl WorldState {
     ) -> bool {
         if data.guid == self.player.guid {
             self.player.instance_sequence = data.instance_sequence;
-            return true;
         }
 
         if let Some(entity) = self.entities.get_mut(data.guid) {
@@ -1118,6 +1081,8 @@ impl WorldState {
                 guid: data.guid,
                 physics_state: data.physics_state,
             });
+            true
+        } else if data.guid == self.player.guid {
             true
         } else {
             false

--- a/crates/holtburger-world/src/state/tests.rs
+++ b/crates/holtburger-world/src/state/tests.rs
@@ -15,7 +15,7 @@ use crate::stats::{Skill, SkillType, TrainingLevel};
 use holtburger_common::position::WorldPosition;
 use holtburger_common::properties::{
     PhysicsState, PropertyInt, PropertyInt64, WorldObjectExt as _, WorldObjectProperties,
-    WorldObjectPropertyAccessorsMut,
+    WorldObjectPropertyAccessors, WorldObjectPropertyAccessorsMut,
 };
 use holtburger_common::{CharacterOption, CharacterOptions1, CharacterOptions2};
 use holtburger_dat::file_type::{
@@ -637,11 +637,7 @@ fn set_local_player_runtime_pose_only_emits_runtime_body_change() {
         rotation: holtburger_common::math::Quaternion::identity(),
     };
 
-    state.player.guid = player_guid;
-    state.player.position = start_pos;
-    state
-        .entities
-        .insert(Entity::new(player_guid, "Player".to_string(), start_pos));
+    state.seed_local_player_entity(player_guid, "Player", start_pos);
 
     let events = state.set_local_player_runtime_pose(WorldPosition {
         coords: Vector3::new(4.0, 5.0, 6.0),
@@ -713,13 +709,7 @@ fn authoritative_player_snapshots_do_not_clobber_active_local_runtime_motion() {
         ..authoritative_pose
     };
 
-    state.player.guid = player_guid;
-    state.player.position = authoritative_pose;
-    state.entities.insert(Entity::new(
-        player_guid,
-        "Player".to_string(),
-        authoritative_pose,
-    ));
+    state.seed_local_player_entity(player_guid, "Player", authoritative_pose);
 
     let runtime_events = state.apply_solved_body_kinematics(&SolvedBodyKinematics {
         body_id: SpatialBodyId::LocalPlayer(player_guid),
@@ -760,11 +750,7 @@ fn local_forced_reposition_uses_single_reset_reconcile_path() {
         ..start_pos
     };
 
-    state.player.guid = player_guid;
-    state.player.position = start_pos;
-    state
-        .entities
-        .insert(Entity::new(player_guid, "Player".to_string(), start_pos));
+    state.seed_local_player_entity(player_guid, "Player", start_pos);
 
     let events = state.apply_spatial_body_event(&crate::SpatialBodyEvent::ForcedReposition {
         body_id: SpatialBodyId::LocalPlayer(player_guid),
@@ -856,11 +842,7 @@ fn apply_solved_body_kinematics_updates_local_runtime_body_and_grounded_state() 
         rotation: holtburger_common::math::Quaternion::identity(),
     };
 
-    state.player.guid = player_guid;
-    state.player.position = start_pos;
-    state
-        .entities
-        .insert(Entity::new(player_guid, "Player".to_string(), start_pos));
+    state.seed_local_player_entity(player_guid, "Player", start_pos);
 
     let solved = SolvedBodyKinematics {
         body_id: SpatialBodyId::LocalPlayer(player_guid),
@@ -2242,6 +2224,11 @@ fn test_player_description_initialization() {
     let mut state = WorldState::synthetic();
     let player_guid = Guid(0x50000001);
     let player_name = "TestingPlayer".to_string();
+    let bootstrap_pos = WorldPosition {
+        landblock_id: Guid(0x12340000),
+        coords: Vector3::new(12.0, 34.0, 56.0),
+        rotation: holtburger_common::math::Quaternion::identity(),
+    };
     let options1 =
         CharacterOptions1::USE_CRAFT_SUCCESS_DIALOG | CharacterOptions1::HEAR_ALLEGIANCE_CHAT;
     let options2 = CharacterOptions2::SHOW_HELM | CharacterOptions2::HEAR_GENERAL_CHAT;
@@ -2249,14 +2236,17 @@ fn test_player_description_initialization() {
     let desired_comps = vec![(42, 7), (99, 12)];
     let spellbook_filters = 0xA5A5_5A5A;
     let gameplay_options = vec![0x10, 0x20, 0x30];
+    let mut properties = WorldObjectProperties::default();
+    properties.set_int_prop(PropertyInt::Level, 17);
+    properties.set_int64_prop(PropertyInt64::AvailableExperience, 12345);
 
     let data = PlayerDescriptionEventData {
         guid: player_guid,
         sequence: 1,
         name: player_name.clone(),
         wee_type: 1,
-        pos: Some(WorldPosition::default()),
-        properties: WorldObjectProperties::default(),
+        pos: Some(bootstrap_pos),
+        properties,
         positions: std::collections::BTreeMap::new(),
         attributes: std::collections::BTreeMap::new(),
         skills: std::collections::BTreeMap::new(),
@@ -2285,12 +2275,24 @@ fn test_player_description_initialization() {
 
     assert_eq!(state.player.guid, player_guid);
     assert_eq!(state.player.name(), player_name);
+    assert_eq!(state.player.position, bootstrap_pos);
     assert_eq!(state.player.options1, options1);
     assert_eq!(state.player.options2, options2);
     assert_eq!(state.player.hotbar_spells, hotbar_spells);
     assert_eq!(state.player.desired_comps, desired_comps);
     assert_eq!(state.player.spellbook_filters, spellbook_filters);
     assert_eq!(state.player.gameplay_options, gameplay_options);
+    let player_entity = state
+        .entities
+        .get(player_guid)
+        .expect("player description should eagerly materialize the player entity");
+    assert_eq!(player_entity.name(), player_name);
+    assert_eq!(player_entity.position, bootstrap_pos);
+    assert_eq!(player_entity.get_int_prop(PropertyInt::Level), Some(17));
+    assert_eq!(
+        player_entity.get_int64_prop(PropertyInt64::AvailableExperience),
+        Some(12345)
+    );
     assert!(
         state
             .player
@@ -2423,11 +2425,34 @@ fn test_self_object_create_bootstraps_player_position() {
         coords: Vector3::new(1.0, 2.0, 3.0),
         rotation: holtburger_common::math::Quaternion::identity(),
     };
-    state.player.guid = player_guid;
-    state.player.position = initial_pos;
-    state
-        .entities
-        .insert(Entity::new(player_guid, "Player".to_string(), initial_pos));
+    let player_description = GameMessage::GameEvent(Box::new(GameEventMessage {
+        target: player_guid,
+        sequence: 1,
+        event: GameEvent::PlayerDescription(Box::new(PlayerDescriptionEventData {
+            guid: player_guid,
+            sequence: 1,
+            name: "Player".to_string(),
+            wee_type: 1,
+            pos: Some(initial_pos),
+            properties: WorldObjectProperties::default(),
+            positions: std::collections::BTreeMap::new(),
+            attributes: std::collections::BTreeMap::new(),
+            skills: std::collections::BTreeMap::new(),
+            enchantments: Vec::new(),
+            spells: std::collections::BTreeMap::new(),
+            has_health: true,
+            options1: CharacterOptions1::empty(),
+            options2: CharacterOptions2::empty(),
+            shortcuts: Vec::new(),
+            hotbar_spells: Vec::new(),
+            desired_comps: Vec::new(),
+            spellbook_filters: 0,
+            gameplay_options: Vec::new(),
+            inventory: Vec::new(),
+            equipped_objects: Vec::new(),
+        })),
+    }));
+    let _ = state.handle_message(&player_description);
 
     let bootstrap_pos = WorldPosition {
         landblock_id: Guid(0x12340010),

--- a/crates/holtburger-world/src/state/tests.rs
+++ b/crates/holtburger-world/src/state/tests.rs
@@ -14,8 +14,8 @@ use crate::{
 use crate::stats::{Skill, SkillType, TrainingLevel};
 use holtburger_common::position::WorldPosition;
 use holtburger_common::properties::{
-    PhysicsState, PropertyBool, PropertyInt, PropertyInt64, WorldObjectExt as _, WorldObjectProperties,
-    WorldObjectPropertyAccessors, WorldObjectPropertyAccessorsMut,
+    PhysicsState, PropertyBool, PropertyInt, PropertyInt64, WorldObjectExt as _,
+    WorldObjectProperties, WorldObjectPropertyAccessors, WorldObjectPropertyAccessorsMut,
 };
 use holtburger_common::{CharacterOption, CharacterOptions1, CharacterOptions2};
 use holtburger_dat::file_type::{
@@ -874,7 +874,7 @@ fn apply_solved_body_kinematics_updates_local_runtime_body_and_grounded_state() 
     assert_eq!(runtime_body.pose, solved.pose);
     assert_eq!(runtime_body.velocity, solved.velocity);
     assert_eq!(runtime_body.omega, solved.omega);
-    assert_eq!(state.player.server_grounded, Some(true));
+    assert_eq!(state.player.last_server_grounded, Some(true));
     assert!(events.iter().any(|event| matches!(
         event,
         WorldEvent::RuntimeBodyChanged {
@@ -896,7 +896,7 @@ fn apply_solved_body_kinematics_preserves_player_grounded_cache_when_contact_unk
 
     state.player.guid = player_guid;
     state.seed_local_player_entity(player_guid, "Player", start_pos);
-    state.player.server_grounded = Some(true);
+    state.player.last_server_grounded = Some(true);
 
     let solved = SolvedBodyKinematics {
         body_id: SpatialBodyId::LocalPlayer(player_guid),
@@ -912,7 +912,7 @@ fn apply_solved_body_kinematics_preserves_player_grounded_cache_when_contact_unk
 
     let events = state.apply_solved_body_kinematics(&solved);
 
-    assert_eq!(state.player.server_grounded, Some(true));
+    assert_eq!(state.player.last_server_grounded, Some(true));
     assert!(
         !events
             .iter()
@@ -1897,7 +1897,7 @@ fn test_private_update_position_non_location_is_stored_without_moving_player() {
     assert_eq!(
         state
             .player
-            .position_property(PositionType::LastOutsideDeath),
+            .local_position_overlay(PositionType::LastOutsideDeath),
         Some(saved_position)
     );
 }
@@ -1937,7 +1937,7 @@ fn test_public_update_position_non_location_for_player_is_stored_without_moving_
         live_position
     );
     assert_eq!(
-        state.player.position_property(PositionType::Sanctuary),
+        state.player.local_position_overlay(PositionType::Sanctuary),
         Some(sanctuary_position)
     );
 }
@@ -1987,7 +1987,7 @@ fn test_public_update_position_non_location_for_other_entity_does_not_move_it() 
     assert_eq!(
         state
             .player
-            .position_property(PositionType::LinkedPortalOne),
+            .local_position_overlay(PositionType::LinkedPortalOne),
         None
     );
 }
@@ -3004,11 +3004,7 @@ fn apply_set_state_updates_local_player_instance_sequence_and_entity_physics_sta
     let mut state = WorldState::synthetic();
     state.player.guid = Guid(0x5000_0001);
     state.player.instance_sequence = 0;
-    state.seed_local_player_entity(
-        state.player.guid,
-        "Player",
-        WorldPosition::default(),
-    );
+    state.seed_local_player_entity(state.player.guid, "Player", WorldPosition::default());
     let mut events = Vec::new();
 
     let handled = state.apply_set_state_update(

--- a/crates/holtburger-world/src/state/tests.rs
+++ b/crates/holtburger-world/src/state/tests.rs
@@ -14,7 +14,7 @@ use crate::{
 use crate::stats::{Skill, SkillType, TrainingLevel};
 use holtburger_common::position::WorldPosition;
 use holtburger_common::properties::{
-    PhysicsState, PropertyInt, PropertyInt64, WorldObjectExt as _, WorldObjectProperties,
+    PhysicsState, PropertyBool, PropertyInt, PropertyInt64, WorldObjectExt as _, WorldObjectProperties,
     WorldObjectPropertyAccessors, WorldObjectPropertyAccessorsMut,
 };
 use holtburger_common::{CharacterOption, CharacterOptions1, CharacterOptions2};
@@ -605,7 +605,7 @@ fn resolve_body_projection_input_falls_back_to_velocity_for_airborne_body() {
 }
 
 #[test]
-fn test_player_mirror_invariant_on_set_vector() {
+fn test_set_player_vector_updates_authoritative_player_entity() {
     let mut state = WorldState::synthetic();
     let player_guid = Guid(0x50000123);
     state.player.guid = player_guid;
@@ -757,7 +757,7 @@ fn local_forced_reposition_uses_single_reset_reconcile_path() {
         pose: forced_pos,
     });
 
-    assert_eq!(state.player.position, start_pos);
+    assert_eq!(state.player_position(), Some(start_pos));
     assert_eq!(state.entities.get(player_guid).unwrap().position, start_pos);
     assert_eq!(
         state
@@ -804,10 +804,7 @@ fn test_set_player_position_sanitizes_nan_rotation() {
         coords: Vector3::new(0.0, 0.0, 0.0),
         rotation: holtburger_common::math::Quaternion::identity(),
     };
-    state.player.position = initial_pos;
-
-    let player_entity = Entity::new(player_guid, "Player".to_string(), initial_pos);
-    state.entities.insert(player_entity);
+    state.seed_local_player_entity(player_guid, "Player", initial_pos);
 
     let nan_pos = WorldPosition {
         landblock_id: Guid(0x12340000),
@@ -823,7 +820,10 @@ fn test_set_player_position_sanitizes_nan_rotation() {
     state.set_player_position(nan_pos);
 
     assert_eq!(
-        state.player.position.rotation,
+        state
+            .player_position()
+            .expect("player entity should exist")
+            .rotation,
         holtburger_common::math::Quaternion::identity()
     );
     assert_eq!(
@@ -859,11 +859,11 @@ fn apply_solved_body_kinematics_updates_local_runtime_body_and_grounded_state() 
 
     let events = state.apply_solved_body_kinematics(&solved);
 
-    assert_eq!(state.player.position, start_pos);
+    assert_eq!(state.player_position(), Some(start_pos));
     let entity = state
         .entities
         .get(player_guid)
-        .expect("player entity should stay mirrored");
+        .expect("authoritative player entity should still exist");
     assert_eq!(entity.position, start_pos);
     assert_eq!(entity.velocity, Vector3::zero());
     assert_eq!(entity.omega, Vector3::zero());
@@ -895,11 +895,8 @@ fn apply_solved_body_kinematics_preserves_player_grounded_cache_when_contact_unk
     let start_pos = WorldPosition::default();
 
     state.player.guid = player_guid;
-    state.player.position = start_pos;
+    state.seed_local_player_entity(player_guid, "Player", start_pos);
     state.player.server_grounded = Some(true);
-    state
-        .entities
-        .insert(Entity::new(player_guid, "Player".to_string(), start_pos));
 
     let solved = SolvedBodyKinematics {
         body_id: SpatialBodyId::LocalPlayer(player_guid),
@@ -971,8 +968,7 @@ fn player_teleport_suspends_runtime_bodies_and_emits_reset_signal() {
     };
 
     state.player.guid = player_guid;
-    state.player.position = position;
-    state.add_entity(Entity::new(player_guid, "Player".to_string(), position));
+    state.seed_local_player_entity(player_guid, "Player", position);
 
     let events = state.handle_message(&GameMessage::PlayerTeleport(Box::new(PlayerTeleportData {
         teleport_sequence: 7,
@@ -1099,18 +1095,23 @@ fn test_micro_portal_bundle_supports_runtime_table_lookups() {
     assert!(!state.xp_table.character_level_xp_list.is_empty());
     assert!(!state.spell_catalog.spells.is_empty());
 
-    state.player.set_int_prop(PropertyInt::Level, 1);
-    state
-        .player
+    let player_guid = Guid(0x5000_0101);
+    state.seed_local_player_entity(player_guid, "Player", WorldPosition::default());
+    let player_entity = state
+        .player_entity_mut()
+        .expect("local player entity should exist");
+    player_entity.properties.set_int_prop(PropertyInt::Level, 1);
+    player_entity
+        .properties
         .set_int64_prop(PropertyInt64::TotalExperience, 0);
-    state
-        .player
+    player_entity
+        .properties
         .set_int64_prop(PropertyInt64::AvailableExperience, 1234);
-    state
-        .player
+    player_entity
+        .properties
         .set_int_prop(PropertyInt::AvailableSkillCredits, 5);
-    state
-        .player
+    player_entity
+        .properties
         .set_int64_prop(PropertyInt64::AvailableLuminance, 42);
 
     let level_info = state.get_level_info();
@@ -1270,16 +1271,14 @@ fn test_tick_does_not_integrate_player_velocity() {
     };
 
     state.player.guid = player_guid;
-    state.player.position = player_pos;
-
     let mut player_entity = Entity::new(player_guid, "Player".to_string(), player_pos);
     player_entity.velocity = Vector3::new(3.0, 4.0, 0.0);
-    state.entities.insert(player_entity);
+    state.add_entity(player_entity);
 
     let events = state.tick();
 
     assert!(events.is_empty());
-    assert_eq!(state.player.position, player_pos);
+    assert_eq!(state.player_position(), Some(player_pos));
     assert_eq!(
         state.entities.get(player_guid).unwrap().position,
         player_pos
@@ -1301,20 +1300,18 @@ fn test_tick_does_not_require_runtime_resource_access() {
     };
 
     state.player.guid = player_guid;
-    state.player.position = player_pos;
-
     let mut player_entity = Entity::new(player_guid, "Player".to_string(), player_pos);
     player_entity.velocity = Vector3::new(1.0, 0.0, 0.0);
-    state.entities.insert(player_entity);
+    state.add_entity(player_entity);
 
     let events = state.tick();
 
     assert!(events.is_empty());
-    assert_eq!(state.player.position, player_pos);
+    assert_eq!(state.player_position(), Some(player_pos));
 }
 
 #[test]
-fn test_player_mirror_invariant_on_autonomous_sync() {
+fn test_player_autonomous_sync_updates_authoritative_player_entity() {
     let mut state = WorldState::synthetic();
     let player_guid = Guid(0x50000123);
     state.player.guid = player_guid;
@@ -1348,7 +1345,7 @@ fn test_player_mirror_invariant_on_autonomous_sync() {
         }
     )));
 
-    assert_eq!(state.player.position, sync_data.position);
+    assert_eq!(state.player_position(), Some(sync_data.position));
     assert_eq!(
         state.entities.get(player_guid).unwrap().position,
         sync_data.position
@@ -1370,9 +1367,7 @@ fn test_stale_player_autonomous_sync_is_ignored() {
         coords: Vector3::new(5.0, 5.0, 0.0),
         rotation: holtburger_common::math::Quaternion::identity(),
     };
-    state.player.position = initial_pos;
-    let player_entity = Entity::new(player_guid, "Player".to_string(), initial_pos);
-    state.entities.insert(player_entity);
+    state.seed_local_player_entity(player_guid, "Player", initial_pos);
 
     let sync_data = ServerAutonomousPositionData {
         guid: player_guid,
@@ -1391,7 +1386,7 @@ fn test_stale_player_autonomous_sync_is_ignored() {
     let events = state.apply_player_autonomous_position(&sync_data);
 
     assert!(events.is_empty());
-    assert_eq!(state.player.position, initial_pos);
+    assert_eq!(state.player_position(), Some(initial_pos));
     assert_eq!(
         state.entities.get(player_guid).unwrap().position,
         initial_pos
@@ -1454,8 +1449,7 @@ fn test_stale_remote_update_position_is_ignored_when_force_sequence_regresses() 
         rotation: holtburger_common::math::Quaternion::identity(),
     };
     state.player.guid = player_guid;
-    state.player.position = initial_pos;
-    state.add_entity(Entity::new(player_guid, "Player".to_string(), initial_pos));
+    state.seed_local_player_entity(player_guid, "Player", initial_pos);
 
     let mut entity = Entity::new(guid, "Target".to_string(), initial_pos);
     entity.sequences[4] = 30;
@@ -1878,12 +1872,7 @@ fn test_private_update_position_non_location_is_stored_without_moving_player() {
         coords: Vector3::new(5.0, 5.0, 0.0),
         rotation: holtburger_common::math::Quaternion::identity(),
     };
-    state.player.position = live_position;
-    state.entities.insert(Entity::new(
-        player_guid,
-        "Player".to_string(),
-        live_position,
-    ));
+    state.seed_local_player_entity(player_guid, "Player", live_position);
 
     let saved_position = WorldPosition {
         landblock_id: Guid(0x56780000),
@@ -1900,7 +1889,7 @@ fn test_private_update_position_non_location_is_stored_without_moving_player() {
     )));
 
     assert!(events.is_empty());
-    assert_eq!(state.player.position, live_position);
+    assert_eq!(state.player_position(), Some(live_position));
     assert_eq!(
         state.entities.get(player_guid).unwrap().position,
         live_position
@@ -1924,12 +1913,7 @@ fn test_public_update_position_non_location_for_player_is_stored_without_moving_
         coords: Vector3::new(1.0, 2.0, 3.0),
         rotation: holtburger_common::math::Quaternion::identity(),
     };
-    state.player.position = live_position;
-    state.entities.insert(Entity::new(
-        player_guid,
-        "Player".to_string(),
-        live_position,
-    ));
+    state.seed_local_player_entity(player_guid, "Player", live_position);
 
     let sanctuary_position = WorldPosition {
         landblock_id: Guid(0x9ABC0000),
@@ -1947,7 +1931,7 @@ fn test_public_update_position_non_location_for_player_is_stored_without_moving_
     )));
 
     assert!(events.is_empty());
-    assert_eq!(state.player.position, live_position);
+    assert_eq!(state.player_position(), Some(live_position));
     assert_eq!(
         state.entities.get(player_guid).unwrap().position,
         live_position
@@ -2274,8 +2258,8 @@ fn test_player_description_initialization() {
     state.handle_message(&msg);
 
     assert_eq!(state.player.guid, player_guid);
-    assert_eq!(state.player.name(), player_name);
-    assert_eq!(state.player.position, bootstrap_pos);
+    assert_eq!(state.player_name(), player_name);
+    assert_eq!(state.player_position(), Some(bootstrap_pos));
     assert_eq!(state.player.options1, options1);
     assert_eq!(state.player.options2, options2);
     assert_eq!(state.player.hotbar_spells, hotbar_spells);
@@ -2321,10 +2305,7 @@ fn test_parent_event_does_not_null_player_landblock() {
     };
 
     state.player.guid = player_guid;
-    state.player.position = initial_pos;
-    state
-        .entities
-        .insert(Entity::new(player_guid, "Player".to_string(), initial_pos));
+    state.seed_local_player_entity(player_guid, "Player", initial_pos);
 
     let msg = GameMessage::ParentEvent(Box::new(ParentEventData {
         parent_guid: Guid(0x8000031B),
@@ -2337,7 +2318,13 @@ fn test_parent_event_does_not_null_player_landblock() {
 
     state.handle_message(&msg);
 
-    assert_eq!(state.player.position.landblock_id, initial_pos.landblock_id);
+    assert_eq!(
+        state
+            .player_position()
+            .expect("player entity should exist")
+            .landblock_id,
+        initial_pos.landblock_id
+    );
     assert_eq!(
         state
             .entities
@@ -2360,10 +2347,7 @@ fn test_player_wielder_iid_update_keeps_position() {
     };
 
     state.player.guid = player_guid;
-    state.player.position = initial_pos;
-    state
-        .entities
-        .insert(Entity::new(player_guid, "Player".to_string(), initial_pos));
+    state.seed_local_player_entity(player_guid, "Player", initial_pos);
 
     let msg = GameMessage::PublicUpdatePropertyInstanceId(Box::new(UpdatePropertyInstanceId {
         sequence: 0,
@@ -2374,7 +2358,13 @@ fn test_player_wielder_iid_update_keeps_position() {
 
     state.handle_message(&msg);
 
-    assert_eq!(state.player.position.landblock_id, initial_pos.landblock_id);
+    assert_eq!(
+        state
+            .player_position()
+            .expect("player entity should exist")
+            .landblock_id,
+        initial_pos.landblock_id
+    );
     assert_eq!(
         state
             .entities
@@ -2473,7 +2463,7 @@ fn test_self_object_create_bootstraps_player_position() {
     let msg = GameMessage::ObjectCreate(Box::new(data));
     let events = state.handle_message(&msg);
 
-    assert_eq!(state.player.position, bootstrap_pos);
+    assert_eq!(state.player_position(), Some(bootstrap_pos));
     assert_eq!(
         state.entities.get(player_guid).unwrap().position,
         bootstrap_pos
@@ -2753,8 +2743,7 @@ fn test_player_authoritative_updates_seed_local_player_body() {
         rotation: holtburger_common::math::Quaternion::identity(),
     };
     state.player.guid = player_guid;
-    state.player.position = initial_pos;
-    state.add_entity(Entity::new(player_guid, "Player".to_string(), initial_pos));
+    state.seed_local_player_entity(player_guid, "Player", initial_pos);
 
     let moved = WorldPosition {
         landblock_id: Guid(0x2222_FFFF),
@@ -2768,7 +2757,7 @@ fn test_player_authoritative_updates_seed_local_player_body() {
     let body = state
         .scene
         .body(SpatialBodyId::LocalPlayer(player_guid))
-        .expect("local player body should be reconciled from authoritative mirror");
+        .expect("local player body should be reconciled from authoritative entity state");
     assert_eq!(body.authoritative_pose, Some(moved));
     assert_eq!(body.pose, moved);
     assert_eq!(body.velocity, Vector3::new(4.0, 5.0, 0.0));
@@ -3011,16 +3000,21 @@ fn test_tick_sweeps_expired_deadline_without_movement() {
 }
 
 #[test]
-fn apply_set_state_updates_local_player_instance_sequence() {
+fn apply_set_state_updates_local_player_instance_sequence_and_entity_physics_state() {
     let mut state = WorldState::synthetic();
     state.player.guid = Guid(0x5000_0001);
     state.player.instance_sequence = 0;
+    state.seed_local_player_entity(
+        state.player.guid,
+        "Player",
+        WorldPosition::default(),
+    );
     let mut events = Vec::new();
 
     let handled = state.apply_set_state_update(
         &SetStateData {
             guid: state.player.guid,
-            physics_state: PhysicsState::REPORT_COLLISIONS,
+            physics_state: PhysicsState::REPORT_COLLISIONS | PhysicsState::IGNORE_COLLISIONS,
             instance_sequence: 1649,
             state_sequence: 1,
         },
@@ -3028,8 +3022,35 @@ fn apply_set_state_updates_local_player_instance_sequence() {
     );
 
     assert!(handled);
-    assert!(events.is_empty());
     assert_eq!(state.player.instance_sequence, 1649);
+    let player_entity = state
+        .player_entity()
+        .expect("local player entity should exist");
+    assert_eq!(
+        player_entity.physics_state,
+        PhysicsState::REPORT_COLLISIONS | PhysicsState::IGNORE_COLLISIONS
+    );
+    assert_eq!(
+        player_entity
+            .properties
+            .get_int_prop(PropertyInt::PhysicsState),
+        Some((PhysicsState::REPORT_COLLISIONS | PhysicsState::IGNORE_COLLISIONS).bits() as i32)
+    );
+    assert_eq!(
+        player_entity
+            .properties
+            .get_bool_prop(PropertyBool::IgnoreCollisions),
+        true
+    );
+    assert!(matches!(
+        events.as_slice(),
+        [WorldEvent::EntityStateUpdated {
+            guid,
+            physics_state,
+        }] if *guid == state.player.guid
+            && *physics_state
+                == (PhysicsState::REPORT_COLLISIONS | PhysicsState::IGNORE_COLLISIONS)
+    ));
 }
 
 #[test]
@@ -3098,8 +3119,7 @@ fn test_stationary_tick_starts_visibility_prune_deadline() {
         local_time: Instant::now(),
     });
     state.player.guid = player_guid;
-    state.player.position = player_pos;
-    state.add_entity(Entity::new(player_guid, "Player".to_string(), player_pos));
+    state.seed_local_player_entity(player_guid, "Player", player_pos);
 
     let target_guid = Guid(0x60000130);
     state.add_entity(Entity::new(target_guid, "Distant".to_string(), far_pos));
@@ -3135,8 +3155,7 @@ fn test_visibility_timeout_sweeps_world_entity_after_25_seconds() {
         local_time: Instant::now(),
     });
     state.player.guid = player_guid;
-    state.player.position = player_pos;
-    state.add_entity(Entity::new(player_guid, "Player".to_string(), player_pos));
+    state.seed_local_player_entity(player_guid, "Player", player_pos);
 
     let target_guid = Guid(0x60000131);
     state.add_entity(Entity::new(target_guid, "Distant".to_string(), far_pos));
@@ -3182,8 +3201,7 @@ fn test_reentry_before_timeout_clears_visibility_prune_deadline() {
         local_time: Instant::now(),
     });
     state.player.guid = player_guid;
-    state.player.position = player_pos;
-    state.add_entity(Entity::new(player_guid, "Player".to_string(), player_pos));
+    state.seed_local_player_entity(player_guid, "Player", player_pos);
 
     let target_guid = Guid(0x60000132);
     state.add_entity(Entity::new(target_guid, "Traveler".to_string(), far_pos));
@@ -3239,8 +3257,7 @@ fn test_indoor_player_keeps_nearby_outdoor_entity_visible_under_conservative_heu
         local_time: Instant::now(),
     });
     state.player.guid = player_guid;
-    state.player.position = player_pos;
-    state.add_entity(Entity::new(player_guid, "Player".to_string(), player_pos));
+    state.seed_local_player_entity(player_guid, "Player", player_pos);
 
     let target_guid = Guid(0x60000136);
     state.add_entity(Entity::new(
@@ -3271,8 +3288,7 @@ fn test_nearby_entities_omit_explicit_delete_and_null_landblock() {
     };
 
     state.player.guid = player_guid;
-    state.player.position = player_pos;
-    state.add_entity(Entity::new(player_guid, "Player".to_string(), player_pos));
+    state.seed_local_player_entity(player_guid, "Player", player_pos);
 
     let visible_guid = Guid(0x60000133);
     state.add_entity(Entity::new(visible_guid, "Visible".to_string(), player_pos));
@@ -3976,8 +3992,7 @@ fn test_tick_does_not_prune_off_world_entities_with_inventory_equipment_or_open_
         local_time: Instant::now(),
     });
     state.player.guid = player_guid;
-    state.player.position = player_pos;
-    state.add_entity(Entity::new(player_guid, "Player".to_string(), player_pos));
+    state.seed_local_player_entity(player_guid, "Player", player_pos);
 
     let mut inventory_entity = Entity::new(
         inventory_guid,

--- a/crates/holtburger-world/src/state/tests.rs
+++ b/crates/holtburger-world/src/state/tests.rs
@@ -2255,7 +2255,7 @@ fn test_player_description_initialization() {
         event,
     }));
 
-    state.handle_message(&msg);
+    let events = state.handle_message(&msg);
 
     assert_eq!(state.player.guid, player_guid);
     assert_eq!(state.player_name(), player_name);
@@ -2277,6 +2277,17 @@ fn test_player_description_initialization() {
         player_entity.get_int64_prop(PropertyInt64::AvailableExperience),
         Some(12345)
     );
+    assert!(events.iter().any(|event| matches!(
+        event,
+        WorldEvent::PlayerInfo(data)
+            if data.entity.guid == player_guid
+                && data.entity.name() == player_name
+                && data.entity.position == bootstrap_pos
+                && data.level_info.level == 17
+    )));
+    assert!(events.iter().any(
+        |event| matches!(event, WorldEvent::LevelInfoUpdated(level_info) if level_info.level == 17)
+    ));
     assert!(
         state
             .player

--- a/crates/holtburger-world/src/state/tests.rs
+++ b/crates/holtburger-world/src/state/tests.rs
@@ -3043,11 +3043,10 @@ fn apply_set_state_updates_local_player_instance_sequence_and_entity_physics_sta
             .get_int_prop(PropertyInt::PhysicsState),
         Some((PhysicsState::REPORT_COLLISIONS | PhysicsState::IGNORE_COLLISIONS).bits() as i32)
     );
-    assert_eq!(
+    assert!(
         player_entity
             .properties
-            .get_bool_prop(PropertyBool::IgnoreCollisions),
-        true
+            .get_bool_prop(PropertyBool::IgnoreCollisions)
     );
     assert!(matches!(
         events.as_slice(),

--- a/crates/holtburger-world/src/state/types.rs
+++ b/crates/holtburger-world/src/state/types.rs
@@ -1,10 +1,11 @@
 use holtburger_common::Guid;
 use holtburger_common::properties::{
-    EnchantmentTypeFlags, EquipMask, PropertyFloat, PropertyInt, WorldObjectExt as _,
-    WorldObjectPropertyAccessors, WorldObjectPropertyAccessorsMut,
+    EnchantmentTypeFlags, EquipMask, PropertyFloat, PropertyInt, PropertyInt64, PropertyString,
+    WorldObjectExt as _, WorldObjectPropertyAccessors, WorldObjectPropertyAccessorsMut,
 };
 use holtburger_dat::file_type::{MotionKinematics, SkillTable, XpTable};
 use holtburger_protocol::messages::GameMessage;
+use holtburger_protocol::messages::combat::CombatMode;
 use std::sync::Arc;
 
 use crate::entity::{Entity, EntityManager};
@@ -30,16 +31,17 @@ pub struct ServerTimeSync {
 /// together. Protocol routing itself lives in `crate::handlers`; `WorldState::handle_message()` is
 /// just the stable facade used by callers such as `holtburger-core`.
 ///
-/// NOTE: The player's authoritative state is partially mirrored between `self.player`
-/// (session sequence data plus authoritative snapshots) and the `Entity` map.
+/// NOTE: The player `Entity` is the authoritative holder of player world/object state.
+/// `self.player` only owns local-player/session overlays such as sequencing, stat caches,
+/// enchantments, inventory/equipment indices, and related derived-state bookkeeping.
 /// Live local runtime motion is world-owned through `SpatialScene`, which composes
 /// shared body-sampling state without exposing it as an app-facing projection surface.
 ///
 /// !!! CRITICAL !!!
 /// Use `set_player_*` and related authoritative world mutation helpers for server-confirmed
 /// player updates and reconciliation. Use the runtime-body helpers for routine local simulation.
-/// Hand-writing to `self.player.position`, `self.entities`, or scene body state directly will
-/// break the authority/runtime split and is not allowed.
+/// Hand-writing to `self.entities` or scene body state directly will break the
+/// authority/runtime split and is not allowed.
 pub struct WorldState {
     pub entities: EntityManager,
     pub player: PlayerState,
@@ -73,9 +75,7 @@ impl WorldState {
     }
 
     pub fn player_position(&self) -> Option<holtburger_common::position::WorldPosition> {
-        self.player_entity()
-            .map(|entity| entity.position)
-            .or_else(|| (self.player.guid != Guid::NULL).then_some(self.player.position))
+        self.player_entity().map(|entity| entity.position)
     }
 
     pub fn player_landblock(&self) -> Option<Guid> {
@@ -84,10 +84,10 @@ impl WorldState {
             .filter(|landblock| *landblock != Guid::NULL)
     }
 
-    pub fn player_properties(&self) -> Option<&holtburger_common::properties::WorldObjectProperties> {
-        self.player_entity()
-            .map(|entity| &entity.properties)
-            .or_else(|| (self.player.guid != Guid::NULL).then_some(&self.player.properties))
+    pub fn player_properties(
+        &self,
+    ) -> Option<&holtburger_common::properties::WorldObjectProperties> {
+        self.player_entity().map(|entity| &entity.properties)
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -98,8 +98,155 @@ impl WorldState {
         position: holtburger_common::position::WorldPosition,
     ) {
         self.player.guid = guid;
-        self.player.position = position;
         self.add_entity(Entity::new(guid, name.into(), position));
+    }
+
+    pub fn player_int_property(&self, property: PropertyInt) -> Option<i32> {
+        self.player_properties()
+            .and_then(|properties| properties.get_int_prop(property))
+    }
+
+    pub fn player_int64_property(&self, property: PropertyInt64) -> Option<i64> {
+        self.player_properties()
+            .and_then(|properties| properties.get_int64_prop(property))
+    }
+
+    pub fn player_float_property(&self, property: PropertyFloat) -> Option<f64> {
+        self.player_properties()
+            .and_then(|properties| properties.get_float_prop(property))
+    }
+
+    pub fn player_string_property(&self, property: PropertyString) -> Option<&str> {
+        self.player_properties()
+            .and_then(|properties| properties.get_string_prop(property))
+    }
+
+    pub fn player_level(&self) -> u32 {
+        self.player_int_property(PropertyInt::Level).unwrap_or(0) as u32
+    }
+
+    pub fn player_total_experience(&self) -> u64 {
+        self.player_int64_property(PropertyInt64::TotalExperience)
+            .unwrap_or(0) as u64
+    }
+
+    pub fn player_available_experience(&self) -> u64 {
+        self.player_int64_property(PropertyInt64::AvailableExperience)
+            .unwrap_or(0) as u64
+    }
+
+    pub fn player_unspent_skill_points(&self) -> u32 {
+        self.player_int_property(PropertyInt::AvailableSkillCredits)
+            .unwrap_or(0) as u32
+    }
+
+    pub fn player_available_luminance(&self) -> u64 {
+        self.player_int64_property(PropertyInt64::AvailableLuminance)
+            .unwrap_or(0) as u64
+    }
+
+    pub fn player_combat_mode(&self) -> CombatMode {
+        let value = self
+            .player_int_property(PropertyInt::CombatMode)
+            .unwrap_or(0);
+        CombatMode::from_repr(value as u32).unwrap_or(CombatMode::NonCombat)
+    }
+
+    pub fn player_name(&self) -> &str {
+        self.player_string_property(PropertyString::Name)
+            .unwrap_or("Unknown")
+    }
+
+    pub fn player_armor(&self) -> i32 {
+        let base_armor = self
+            .player_int_property(PropertyInt::ArmorLevel)
+            .unwrap_or(0);
+        i32::max(
+            -400,
+            crate::magic::get_enchanted_armor(base_armor, &self.player.enchantments),
+        )
+    }
+
+    pub fn player_vitae(&self) -> f32 {
+        self.player.vitae()
+    }
+
+    fn player_resistance_augmentation(&self, prop: PropertyFloat) -> i32 {
+        let augmentation_prop = match prop {
+            PropertyFloat::ResistSlash => PropertyInt::AugmentationResistanceSlash,
+            PropertyFloat::ResistPierce => PropertyInt::AugmentationResistancePierce,
+            PropertyFloat::ResistBludgeon => PropertyInt::AugmentationResistanceBlunt,
+            PropertyFloat::ResistFire => PropertyInt::AugmentationResistanceFire,
+            PropertyFloat::ResistCold => PropertyInt::AugmentationResistanceFrost,
+            PropertyFloat::ResistAcid => PropertyInt::AugmentationResistanceAcid,
+            PropertyFloat::ResistElectric => PropertyInt::AugmentationResistanceLightning,
+            PropertyFloat::ResistNether => PropertyInt::AugmentationResistanceNether,
+            _ => return 0,
+        };
+
+        self.player_int_property(augmentation_prop).unwrap_or(0)
+    }
+
+    pub fn player_resistance_current(&self, prop: PropertyFloat) -> f32 {
+        let base = self.player_float_property(prop).unwrap_or(1.0) as f32;
+        let strength_base = self
+            .player
+            .get_attribute_base(crate::stats::AttributeType::StrengthAttr);
+        let endurance_base = self
+            .player
+            .get_attribute_base(crate::stats::AttributeType::EnduranceAttr);
+        let augmentation_resistance = self.player_resistance_augmentation(prop);
+
+        crate::magic::get_player_enchanted_resistance(
+            base,
+            &self.player.enchantments,
+            prop as u32,
+            strength_base,
+            endurance_base,
+            augmentation_resistance,
+        )
+    }
+
+    pub fn player_resistances(&self) -> stats::Resistances {
+        stats::Resistances {
+            slash: self.player_resistance_current(PropertyFloat::ResistSlash),
+            pierce: self.player_resistance_current(PropertyFloat::ResistPierce),
+            bludgeon: self.player_resistance_current(PropertyFloat::ResistBludgeon),
+            fire: self.player_resistance_current(PropertyFloat::ResistFire),
+            cold: self.player_resistance_current(PropertyFloat::ResistCold),
+            acid: self.player_resistance_current(PropertyFloat::ResistAcid),
+            electric: self.player_resistance_current(PropertyFloat::ResistElectric),
+            nether: self.player_resistance_current(PropertyFloat::ResistNether),
+        }
+    }
+
+    pub(crate) fn emit_player_derived_stats(&mut self, events: &mut Vec<WorldEvent>) {
+        self.player.refresh_cached_derived_stat_inputs();
+
+        let current = crate::player::types::LastSentStats {
+            attributes: self.player.get_attributes(),
+            vitals: self.player.get_vitals(),
+            skills: self.player.get_skills(),
+            resistances: self.player_resistances(),
+            armor: self.player_armor(),
+            vitae: self.player_vitae(),
+        };
+
+        if self.player.last_sent_stats.as_ref() == Some(&current) {
+            return;
+        }
+
+        self.player.last_sent_stats = Some(current.clone());
+        events.push(WorldEvent::DerivedStatsUpdated(Box::new(
+            crate::DerivedStatsData {
+                attributes: current.attributes,
+                vitals: current.vitals,
+                skills: current.skills,
+                resistances: current.resistances,
+                armor: current.armor,
+                vitae: current.vitae,
+            },
+        )));
     }
 
     /// Stable public entry point for applying a decoded game message to world state.
@@ -126,9 +273,9 @@ impl WorldState {
 
     pub fn get_level_info(&self) -> stats::CharacterLevelInfo {
         let table = &self.xp_table;
-        let level = self.player.level();
-        let total_xp = self.player.total_experience();
-        let unspent_xp = self.player.available_experience();
+        let level = self.player_level();
+        let total_xp = self.player_total_experience();
+        let unspent_xp = self.player_available_experience();
 
         let level_idx = level as usize;
         let next_level_idx = level_idx + 1;
@@ -140,8 +287,8 @@ impl WorldState {
                 level,
                 current_xp: total_xp,
                 unspent_xp,
-                unspent_skill_points: self.player.unspent_skill_points(),
-                available_luminance: self.player.available_luminance(),
+                unspent_skill_points: self.player_unspent_skill_points(),
+                available_luminance: self.player_available_luminance(),
                 next_level_xp: level_xp,
                 xp_into_level: total_xp.saturating_sub(level_xp),
                 xp_for_next_level: 0,
@@ -155,8 +302,8 @@ impl WorldState {
             level,
             current_xp: total_xp,
             unspent_xp,
-            unspent_skill_points: self.player.unspent_skill_points(),
-            available_luminance: self.player.available_luminance(),
+            unspent_skill_points: self.player_unspent_skill_points(),
+            available_luminance: self.player_available_luminance(),
             next_level_xp,
             xp_into_level: total_xp.saturating_sub(level_xp),
             xp_for_next_level: next_level_xp.saturating_sub(level_xp),
@@ -208,7 +355,7 @@ impl WorldState {
                 | PropertyFloat::ResistElectric
                 | PropertyFloat::ResistNether
         ) {
-            return self.player.get_resistance_current(key);
+            return self.player_resistance_current(key);
         }
 
         let base = self

--- a/crates/holtburger-world/src/state/types.rs
+++ b/crates/holtburger-world/src/state/types.rs
@@ -224,19 +224,19 @@ impl WorldState {
         self.player.refresh_cached_derived_stat_inputs();
 
         let current = crate::player::types::LastSentStats {
-            attributes: self.player.get_attributes(),
-            vitals: self.player.get_vitals(),
-            skills: self.player.get_skills(),
+            attributes: self.player.attribute_snapshot(),
+            vitals: self.player.vital_snapshot(),
+            skills: self.player.skill_snapshot(),
             resistances: self.player_resistances(),
             armor: self.player_armor(),
             vitae: self.player_vitae(),
         };
 
-        if self.player.last_sent_stats.as_ref() == Some(&current) {
+        if self.player.last_emitted_derived_stats.as_ref() == Some(&current) {
             return;
         }
 
-        self.player.last_sent_stats = Some(current.clone());
+        self.player.last_emitted_derived_stats = Some(current.clone());
         events.push(WorldEvent::DerivedStatsUpdated(Box::new(
             crate::DerivedStatsData {
                 attributes: current.attributes,

--- a/crates/holtburger-world/src/state/types.rs
+++ b/crates/holtburger-world/src/state/types.rs
@@ -58,6 +58,50 @@ pub struct WorldState {
 }
 
 impl WorldState {
+    pub fn player_entity(&self) -> Option<&Entity> {
+        let guid = self.player.guid;
+        (guid != Guid::NULL)
+            .then(|| self.entities.get(guid))
+            .flatten()
+    }
+
+    pub fn player_entity_mut(&mut self) -> Option<&mut Entity> {
+        let guid = self.player.guid;
+        (guid != Guid::NULL)
+            .then(|| self.entities.get_mut(guid))
+            .flatten()
+    }
+
+    pub fn player_position(&self) -> Option<holtburger_common::position::WorldPosition> {
+        self.player_entity()
+            .map(|entity| entity.position)
+            .or_else(|| (self.player.guid != Guid::NULL).then_some(self.player.position))
+    }
+
+    pub fn player_landblock(&self) -> Option<Guid> {
+        self.player_position()
+            .map(|position| position.landblock_id)
+            .filter(|landblock| *landblock != Guid::NULL)
+    }
+
+    pub fn player_properties(&self) -> Option<&holtburger_common::properties::WorldObjectProperties> {
+        self.player_entity()
+            .map(|entity| &entity.properties)
+            .or_else(|| (self.player.guid != Guid::NULL).then_some(&self.player.properties))
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn seed_local_player_entity(
+        &mut self,
+        guid: Guid,
+        name: impl Into<String>,
+        position: holtburger_common::position::WorldPosition,
+    ) {
+        self.player.guid = guid;
+        self.player.position = position;
+        self.add_entity(Entity::new(guid, name.into(), position));
+    }
+
     /// Stable public entry point for applying a decoded game message to world state.
     ///
     /// Feature handlers own the orchestration order; this method preserves the external API while
@@ -131,8 +175,7 @@ impl WorldState {
 
     pub fn get_player_enchanted_int(&self, key: PropertyInt) -> i32 {
         let base = self
-            .entities
-            .get(self.player.guid)
+            .player_entity()
             .and_then(|e| e.get_int_prop(key))
             .unwrap_or(0);
 
@@ -169,8 +212,7 @@ impl WorldState {
         }
 
         let base = self
-            .entities
-            .get(self.player.guid)
+            .player_entity()
             .and_then(|e| e.get_float_prop(key))
             .map(|f| f as f32)
             .unwrap_or(1.0);

--- a/docs/plans/player-entity-authority-refactor-plan.md
+++ b/docs/plans/player-entity-authority-refactor-plan.md
@@ -313,8 +313,8 @@ Mitigation:
 - [x] Phase 3: delete property mirroring in handlers/mutations
 - [x] Phase 4: simplify movement/liveness/runtime-body special casing
 - [x] Phase 5: trim or rename `PlayerState` APIs/docs
-- [ ] Phase 6: retarget downstream crates and tests
-- [ ] Final verification across world/core/cli
+- [x] Phase 6: retarget downstream crates and tests
+- [x] Final verification across world/core/cli
 
 ### Decisions Log
 
@@ -338,6 +338,8 @@ Mitigation:
 - Phase 5 decision: keep the type name `PlayerState`; after the ownership cut it still accurately describes the session-local state model for the current player, while avoiding churn that would not buy additional architectural clarity.
 - Phase 5 decision: rename remaining overlay-oriented `PlayerState` APIs and fields to advertise their reduced role explicitly (`last_server_grounded`, `local_position_overlays`, derived-stat snapshot naming) so callers do not mistake them for generic world/entity state.
 - Phase 5 decision: `PlayerInfoData` should carry a single authoritative player `Entity` snapshot plus player-local overlays, rather than parallel `guid`/`name`/`pos` fields that duplicate the entity snapshot shape.
+- Phase 6 decision: keep downstream CLI projection logic centered on entity readiness and `ClientViewEvent` projection rather than introducing any frontend-side `PlayerState` compatibility shim; the downstream work is test/doc retargeting and regression proof, not a new API layer.
+- Phase 6 decision: the final regression set should explicitly cover authoritative `PlayerInfo` composition at both boundaries: world emits an entity-backed snapshot, and core projects that snapshot back into the frontend entity stream.
 
 ### Progress Log
 
@@ -366,6 +368,10 @@ Mitigation:
 - Simplified `PlayerInfoData` to carry one authoritative player entity snapshot plus local-player overlays, and retargeted world/core projection code to that explicit composition model.
 - Updated architecture/docs wording to describe `PlayerState` as session-local overlay state rather than a second world object.
 - Verification: `cargo test -p holtburger-world -p holtburger-core` passed after the Phase 5 changes.
+- 2026-04-20: completed Phase 6 downstream cleanup and final verification.
+- Audited the actual CLI package (`apps/holtburger-cli`) and downstream core/world surfaces for stale ownership assumptions; no new compatibility layer was needed because the TUI was already consuming entity-oriented readiness and projection state.
+- Added focused regression coverage so world bootstrap tests assert the authoritative `PlayerInfo` entity snapshot and core message tests assert that `PlayerInfo` projection re-emits the player entity through `ClientViewEvent::EntitySpawned`.
+- Verification: `cargo test -p holtburger-world -p holtburger-core -p holtburger-cli` passed, and `cargo test --all` passed after the final changes.
 
 ### Open Questions
 

--- a/docs/plans/player-entity-authority-refactor-plan.md
+++ b/docs/plans/player-entity-authority-refactor-plan.md
@@ -311,7 +311,7 @@ Mitigation:
 - [x] Phase 3: remove `PlayerState.position`
 - [x] Phase 3: remove `PlayerState.properties`
 - [x] Phase 3: delete property mirroring in handlers/mutations
-- [ ] Phase 4: simplify movement/liveness/runtime-body special casing
+- [x] Phase 4: simplify movement/liveness/runtime-body special casing
 - [ ] Phase 5: trim or rename `PlayerState` APIs/docs
 - [ ] Phase 6: retarget downstream crates and tests
 - [ ] Final verification across world/core/cli
@@ -332,6 +332,9 @@ Mitigation:
 - Phase 3 decision: property-derived player reads now live on `WorldState` (`player_name`, `player_level`, XP/combat-mode/armor/vitae/resistance helpers) so callers consume entity-authored state through a single surface instead of reaching into `PlayerState`.
 - Phase 3 decision: derived stat emission that depends on entity properties is now orchestrated from `WorldState`/world handlers rather than from `PlayerState` mutation methods, which keeps player-local stat caches separate from entity-authored property projection.
 - Phase 3 decision: world/core tests should seed local-player authority through the player entity helper path (`seed_local_player_entity(...)`) and assert through `WorldState` accessors rather than mutating or reading removed `player.position` / `player.properties` mirrors.
+- Phase 4 decision: local-player branching should remain only where the semantics are genuinely self-specific, such as `SpatialBodyId::LocalPlayer(...)`, self sequencing, player-local position-property overlays, or self-side trade/fellowship projection. Branches whose only job was choosing between mirrored storage locations should be removed.
+- Phase 4 decision: runtime and movement code should prefer body identity over GUID equality when the distinction is “local player body versus remote body,” and should prefer shared entity-backed helpers over hand-written self fallbacks when the distinction is only storage access.
+- Phase 4 decision: self `SetState` remains responsible for advancing player-local instance sequencing, but it must also hydrate the authoritative player entity's physics state/properties when that entity exists so self physics-state updates are not silently dropped.
 
 ### Progress Log
 
@@ -350,6 +353,11 @@ Mitigation:
 - Deleted the player property-mirroring path from property application and retargeted player-derived stat emission so handlers/world code explicitly project derived stats after player-local stat or enchantment mutations.
 - Retargeted world/core tests and helper setup away from direct `player.position` / `player.properties` mutation so local-player authority is always seeded through the player entity path.
 - Verification: `cargo test -p holtburger-world -p holtburger-core` passed after the Phase 3 changes.
+- 2026-04-20: completed Phase 4 special-case collapse across movement, runtime bodies, and liveness-facing helper paths.
+- Removed redundant self-storage fallback branches from world/core movement/runtime code so local-player pose and kinematics now resolve through the same entity-backed/runtime-body helper surface as other authoritative bodies.
+- Tightened runtime tracking to distinguish the local player by `SpatialBodyId::LocalPlayer(...)` instead of GUID equality where the semantics are body identity rather than storage ownership.
+- Simplified world movement handling so self-only branches remain only for true self semantics, and fixed self `SetState` handling so it no longer drops authoritative physics-state hydration for the local player entity.
+- Verification: `cargo test -p holtburger-world -p holtburger-core` passed after the Phase 4 changes.
 
 ### Open Questions
 

--- a/docs/plans/player-entity-authority-refactor-plan.md
+++ b/docs/plans/player-entity-authority-refactor-plan.md
@@ -312,7 +312,7 @@ Mitigation:
 - [x] Phase 3: remove `PlayerState.properties`
 - [x] Phase 3: delete property mirroring in handlers/mutations
 - [x] Phase 4: simplify movement/liveness/runtime-body special casing
-- [ ] Phase 5: trim or rename `PlayerState` APIs/docs
+- [x] Phase 5: trim or rename `PlayerState` APIs/docs
 - [ ] Phase 6: retarget downstream crates and tests
 - [ ] Final verification across world/core/cli
 
@@ -335,6 +335,9 @@ Mitigation:
 - Phase 4 decision: local-player branching should remain only where the semantics are genuinely self-specific, such as `SpatialBodyId::LocalPlayer(...)`, self sequencing, player-local position-property overlays, or self-side trade/fellowship projection. Branches whose only job was choosing between mirrored storage locations should be removed.
 - Phase 4 decision: runtime and movement code should prefer body identity over GUID equality when the distinction is “local player body versus remote body,” and should prefer shared entity-backed helpers over hand-written self fallbacks when the distinction is only storage access.
 - Phase 4 decision: self `SetState` remains responsible for advancing player-local instance sequencing, but it must also hydrate the authoritative player entity's physics state/properties when that entity exists so self physics-state updates are not silently dropped.
+- Phase 5 decision: keep the type name `PlayerState`; after the ownership cut it still accurately describes the session-local state model for the current player, while avoiding churn that would not buy additional architectural clarity.
+- Phase 5 decision: rename remaining overlay-oriented `PlayerState` APIs and fields to advertise their reduced role explicitly (`last_server_grounded`, `local_position_overlays`, derived-stat snapshot naming) so callers do not mistake them for generic world/entity state.
+- Phase 5 decision: `PlayerInfoData` should carry a single authoritative player `Entity` snapshot plus player-local overlays, rather than parallel `guid`/`name`/`pos` fields that duplicate the entity snapshot shape.
 
 ### Progress Log
 
@@ -358,8 +361,12 @@ Mitigation:
 - Tightened runtime tracking to distinguish the local player by `SpatialBodyId::LocalPlayer(...)` instead of GUID equality where the semantics are body identity rather than storage ownership.
 - Simplified world movement handling so self-only branches remain only for true self semantics, and fixed self `SetState` handling so it no longer drops authoritative physics-state hydration for the local player entity.
 - Verification: `cargo test -p holtburger-world -p holtburger-core` passed after the Phase 4 changes.
+- 2026-04-20: completed Phase 5 PlayerState clarification and player snapshot cleanup.
+- Renamed the remaining `PlayerState` overlay-facing fields and helper methods so grounded state, private position overlays, and derived-stat snapshots no longer read like duplicated world/object ownership.
+- Simplified `PlayerInfoData` to carry one authoritative player entity snapshot plus local-player overlays, and retargeted world/core projection code to that explicit composition model.
+- Updated architecture/docs wording to describe `PlayerState` as session-local overlay state rather than a second world object.
+- Verification: `cargo test -p holtburger-world -p holtburger-core` passed after the Phase 5 changes.
 
 ### Open Questions
 
 - Should self sequencing remain entirely on `PlayerState`, or should some of it move onto the player entity once the base ownership split is complete?
-- Should `PlayerInfoData` continue exposing `player_entity` as an embedded snapshot, or should it move to a more explicit composition model after the authority split lands?

--- a/docs/plans/player-entity-authority-refactor-plan.md
+++ b/docs/plans/player-entity-authority-refactor-plan.md
@@ -307,10 +307,10 @@ Mitigation:
 - [x] Phase 1: add test helpers for local-player entity setup
 - [x] Phase 1: retarget world/core reads away from mirrored `PlayerState` fields
 - [x] Phase 2: make `PlayerDescription` bootstrap the player entity eagerly
-- [ ] Phase 3: move property-derived player APIs off `PlayerState`
-- [ ] Phase 3: remove `PlayerState.position`
-- [ ] Phase 3: remove `PlayerState.properties`
-- [ ] Phase 3: delete property mirroring in handlers/mutations
+- [x] Phase 3: move property-derived player APIs off `PlayerState`
+- [x] Phase 3: remove `PlayerState.position`
+- [x] Phase 3: remove `PlayerState.properties`
+- [x] Phase 3: delete property mirroring in handlers/mutations
 - [ ] Phase 4: simplify movement/liveness/runtime-body special casing
 - [ ] Phase 5: trim or rename `PlayerState` APIs/docs
 - [ ] Phase 6: retarget downstream crates and tests
@@ -329,6 +329,9 @@ Mitigation:
 - Phase 2 decision: `PlayerDescription` now eagerly creates or refreshes the player entity and writes bootstrap name/properties/position there first, before projecting player-facing events.
 - Phase 2 decision: `PlayerState::hydrate_from_player_description(...)` no longer seeds live player position directly; the authoritative bootstrap pose now comes from world-side entity setup.
 - Phase 2 decision: `PlayerState.properties` remains populated as a compatibility mirror for now because `get_level_info`, `emit_player_info`, and other property-derived APIs still depend on it. Removing that mirror remains Phase 3 work.
+- Phase 3 decision: property-derived player reads now live on `WorldState` (`player_name`, `player_level`, XP/combat-mode/armor/vitae/resistance helpers) so callers consume entity-authored state through a single surface instead of reaching into `PlayerState`.
+- Phase 3 decision: derived stat emission that depends on entity properties is now orchestrated from `WorldState`/world handlers rather than from `PlayerState` mutation methods, which keeps player-local stat caches separate from entity-authored property projection.
+- Phase 3 decision: world/core tests should seed local-player authority through the player entity helper path (`seed_local_player_entity(...)`) and assert through `WorldState` accessors rather than mutating or reading removed `player.position` / `player.properties` mirrors.
 
 ### Progress Log
 
@@ -342,6 +345,11 @@ Mitigation:
 - Stopped `PlayerState::hydrate_from_player_description(...)` from seeding live position directly; bootstrap pose is now synchronized from the authoritative entity path.
 - Retargeted world tests to assert that `PlayerDescription` creates the player entity eagerly and that the self `ObjectCreate` path still works when it arrives after that bootstrap entity already exists.
 - Verification: `cargo test -p holtburger-world` passed and `cargo test -p holtburger-core` passed after the Phase 2 changes.
+- 2026-04-20: completed Phase 3 ownership cut for player properties and live pose.
+- Removed `PlayerState.position`, `PlayerState.properties`, and the `HasProperties` / `HasPropertiesMut` implementation from `PlayerState`; property-derived player APIs now resolve through entity-backed `WorldState` helpers.
+- Deleted the player property-mirroring path from property application and retargeted player-derived stat emission so handlers/world code explicitly project derived stats after player-local stat or enchantment mutations.
+- Retargeted world/core tests and helper setup away from direct `player.position` / `player.properties` mutation so local-player authority is always seeded through the player entity path.
+- Verification: `cargo test -p holtburger-world -p holtburger-core` passed after the Phase 3 changes.
 
 ### Open Questions
 

--- a/docs/plans/player-entity-authority-refactor-plan.md
+++ b/docs/plans/player-entity-authority-refactor-plan.md
@@ -1,0 +1,349 @@
+# Player Entity Authority Refactor Plan
+
+## Goal
+
+Remove local-player world-state mirroring by making the player `Entity` the sole authoritative holder of entity/object state, while shrinking `PlayerState` to local-player-only state that does not belong on a generic world entity.
+
+## Scope
+
+### In Scope
+
+- Make the player entity in `WorldState.entities` authoritative for world/object state, including live position and `WorldObjectProperties`.
+- Remove mirrored player world-state fields from `PlayerState` where they can be read from the player entity instead.
+- Replace local-player special casing in world systems with shared entity-based helpers where practical.
+- Change APIs across crates where needed; this refactor does not preserve backward compatibility for convenience.
+- Retarget tests and helpers to the new ownership model.
+
+### Out Of Scope
+
+- Redesigning player stats/enchantments/spell knowledge beyond moving their base property source onto the entity.
+- Redesigning the protocol surface or ACE parity rules.
+- Reworking frontend UX or `ClientViewEvent` semantics beyond whatever is mechanically required by the ownership shift.
+- General spatial architecture cleanup unrelated to eliminating player/entity duplication.
+
+## Ground Truth
+
+### Reference Sources
+
+- [AGENTS.md](/home/cluracan/code/holtburger/AGENTS.md)
+- [ARCHITECTURE.md](/home/cluracan/code/holtburger/ARCHITECTURE.md)
+- [crates/holtburger-world/src/player/types.rs](/home/cluracan/code/holtburger/crates/holtburger-world/src/player/types.rs)
+- [crates/holtburger-world/src/player/mutations.rs](/home/cluracan/code/holtburger/crates/holtburger-world/src/player/mutations.rs)
+- [crates/holtburger-world/src/entity.rs](/home/cluracan/code/holtburger/crates/holtburger-world/src/entity.rs)
+- [crates/holtburger-world/src/state/types.rs](/home/cluracan/code/holtburger/crates/holtburger-world/src/state/types.rs)
+- [crates/holtburger-world/src/state/mutations.rs](/home/cluracan/code/holtburger/crates/holtburger-world/src/state/mutations.rs)
+- [crates/holtburger-world/src/state/liveness.rs](/home/cluracan/code/holtburger/crates/holtburger-world/src/state/liveness.rs)
+- [crates/holtburger-world/src/handlers/movement.rs](/home/cluracan/code/holtburger/crates/holtburger-world/src/handlers/movement.rs)
+- [crates/holtburger-world/src/handlers/properties.rs](/home/cluracan/code/holtburger/crates/holtburger-world/src/handlers/properties.rs)
+- [crates/holtburger-world/src/context.rs](/home/cluracan/code/holtburger/crates/holtburger-world/src/context.rs)
+- [crates/holtburger-world/src/events.rs](/home/cluracan/code/holtburger/crates/holtburger-world/src/events.rs)
+
+### Existing Patterns
+
+- `WorldState` already treats the player entity as the world-facing base for some reads, such as enchanted int/float lookups.
+- `PlayerState` currently mixes genuinely local state with mirrored world/entity state.
+- Movement and liveness code special-case the local player because `PlayerState.position` is treated as authoritative in parallel with the player entity.
+- Property handlers currently mirror many updates into both the player entity and `PlayerState.properties`.
+- World/context helpers expose player-derived reads through `PlayerState` even when the underlying data is conceptually entity state.
+- `holtburger-core` directly reads and mutates `world.player.position` in production code and tests, so the refactor blast radius is wider than `holtburger-world` alone.
+- `PlayerDescription` currently hydrates `PlayerState` directly, while login/object-create flows update player entity state separately, so bootstrap order is a real ownership seam.
+
+## Problem Statement
+
+The current model has two mutable homes for local-player world state:
+
+- the player `Entity` in `WorldState.entities`
+- mirrored fields on `PlayerState`
+
+That split increases cyclomatic complexity and raises the odds of divergence because systems must answer both of these questions repeatedly:
+
+- is this path operating on an arbitrary entity or specifically the local player?
+- if it is the local player, which copy is authoritative here?
+
+This shows up in movement, liveness, property application, runtime-body views, and world-context reads. The result is avoidable branching and mutation coupling across systems that should otherwise treat the local player as just another entity plus a small amount of session-local metadata.
+
+The refactor target is therefore:
+
+- entity/object state lives on the player `Entity`
+- local/session/stateful overlays live on `PlayerState`
+- `WorldState` provides narrow helpers for "get the player entity" and "get the player entity mutably"
+- world systems stop special-casing the local player merely to choose between duplicated state stores
+
+## Target Ownership Model
+
+### Player Entity Owns
+
+- live world position
+- velocity and omega
+- `WorldObjectProperties`
+- health fraction
+- motion snapshot
+- any other state that conceptually belongs to a generic world object/creature
+
+### PlayerState Owns
+
+- player guid
+- stat caches and stat bases used for derived calculations
+- spell knowledge and active enchantments
+- character options and gameplay option blobs
+- inventory/equipment indices
+- self-session sequencing that is not part of generic entity state
+- client-local flags like `noclip`
+- cached/derived event throttling state such as `last_sent_stats`
+
+### Candidate Fields To Remove From PlayerState
+
+- `position`
+- `properties`
+
+### Candidate Fields To Re-evaluate Carefully
+
+- `instance_sequence`
+- `server_control_sequence`
+- `teleport_sequence`
+- `force_position_sequence`
+- `position_sequence`
+
+These sequence fields may remain on `PlayerState` even after the refactor if they are truly self-session control metadata rather than generic entity state. The plan assumes they stay unless implementation proves consolidating them onto the entity is clearly better.
+
+## Dry-Run Findings
+
+### Confirmed Gaps In The Original Plan
+
+- The original phase breakdown understated the cross-crate churn. Production code in `holtburger-core` falls back to `world.player.position` directly, especially in movement code, so helper introduction must be treated as a workspace-wide migration seam rather than a world-only cleanup.
+- The bootstrap path needs to be explicit. `PlayerDescription` currently seeds player properties and optional position onto `PlayerState` even when no player entity exists yet, while separate login/object-create handlers patch the entity later. Deleting the mirror without changing bootstrap order would break current initialization and tests.
+- `PlayerState` currently implements `HasProperties` and `HasPropertiesMut`, and methods like `name()`, `level()`, `combat_mode()`, and XP-related helpers sit on top of those property reads. Removing `PlayerState.properties` therefore implies an API shape change, not just field deletion.
+- Tests in both `holtburger-world` and `holtburger-core` directly mutate `state.player.position` / `world.player.position`. The plan needs an early testing helper strategy or the churn will be noisy and error-prone.
+
+### Awkward Seams
+
+- `apply_player_description_world_state(...)` currently updates player-facing events and maybe the entity name/position, but does not guarantee the player entity exists. That is the biggest awkward seam for an entity-authoritative model.
+- Runtime-body helpers still branch on `guid == self.player.guid` to choose between `self.player.position` and entity state. Those branches do not disappear automatically just by deleting fields; they need a helper-first rewrite.
+- Context helpers currently read stats from `PlayerState` and properties from `PlayerState` too. After the refactor, those reads need a clean split: stats/enchantments from `PlayerState`, object properties from the player entity.
+- `PlayerInfoData` currently embeds `player_entity` while also carrying a parallel pile of player-local overlays. That is probably acceptable during migration, but it is an obvious place to accidentally reintroduce duplication.
+
+### Better Pattern Than The Original Cut
+
+The dry run suggests a better cut line than simply "remove `position` and `properties` from `PlayerState`":
+
+1. Introduce a first-class `WorldState` player-entity accessor surface and migrate all world/core reads to it.
+2. Materialize or upsert the player entity eagerly during `PlayerDescription` handling so entity-authoritative state exists before later deltas arrive.
+3. Move property-derived APIs off `PlayerState` and onto `WorldState` or dedicated player-entity helper methods.
+4. Only then delete `PlayerState.position` and `PlayerState.properties`.
+
+This sequencing reduces the chance of a half-refactored state where initialization still depends on mirrors.
+
+## Phased Implementation
+
+### Phase 1: Introduce Player Entity Accessors And Test Helpers
+
+#### Deliverables
+
+- Add `WorldState` helpers for reading and mutating the player entity.
+- Add narrow helpers for common player-world reads such as player position, player landblock, and player properties.
+- Add test helpers/builders for seeding a local player entity without direct `world.player.position` mutation.
+- Retarget internal reads in world state, movement, liveness, and context code to those helpers rather than directly reading `self.player.position` or `self.player.properties`.
+- Retarget `holtburger-core` movement/runtime call sites to the helper surface early, before field deletion.
+- Keep `PlayerState` fields in place temporarily, but stop introducing new reads from the mirrored copies.
+
+#### Acceptance Criteria
+
+- world code can obtain player world/object state without directly touching mirrored `PlayerState` fields
+- core movement/runtime code can obtain player world pose without directly touching mirrored `PlayerState` fields
+- movement and liveness logic are expressed in terms of the player entity/helper accessors
+- the number of `guid == self.player.guid` branches used only to select a storage location is materially reduced
+- `cargo test -p holtburger-world` passes
+- `cargo test -p holtburger-core` passes
+
+### Phase 2: Make Player Bootstrap Entity-First
+
+#### Deliverables
+
+- Change `PlayerDescription` hydration so the authoritative player entity is created or upserted eagerly when player bootstrap data arrives.
+- Move player name/property/position bootstrap writes onto the player entity rather than `PlayerState`.
+- Keep `PlayerState` responsible only for local overlays sourced from `PlayerDescription`, such as stats, options, spells, enchantments, inventory/equipment indices, and session metadata.
+- Retarget tests that currently assume `PlayerDescription` populates `PlayerState.properties` or `PlayerState.position` directly.
+
+#### Acceptance Criteria
+
+- player bootstrap succeeds even when no prior player entity exists
+- `PlayerDescription` no longer requires mirrored player world/object fields to seed initial state
+- world tests covering login/bootstrap and self object-create ordering pass
+
+### Phase 3: Move Property-Derived APIs Off PlayerState And Delete Mirrored Fields
+
+#### Deliverables
+
+- Remove `position` and `properties` from `PlayerState`.
+- Remove `HasProperties` and `HasPropertiesMut` from `PlayerState`.
+- Move property-derived APIs like player name/level/combat mode/XP base reads onto `WorldState` or player-entity helpers.
+- Rewrite player movement/property mutation flows so they update only the player entity plus any truly local sequence metadata.
+- Update stat/property-derived helpers to use the player entity as the base property source.
+- Update self-player runtime-body helpers to derive authoritative pose/kinematics from the player entity.
+- Remove the property mirroring path from `apply_property_update_to_target`.
+
+#### Acceptance Criteria
+
+- no persistent copy of player position remains on `PlayerState`
+- no persistent copy of player `WorldObjectProperties` remains on `PlayerState`
+- no production code depends on `PlayerState: HasProperties`
+- movement/property handlers compile and behave with entity-only world/object ownership
+- tests covering self movement, property updates, and liveness still pass after retargeting
+
+### Phase 4: Collapse Local-Player Special Cases Across Systems
+
+#### Deliverables
+
+- Simplify movement handler logic so the player path differs only where sequencing/protocol semantics actually differ, not because the storage model differs.
+- Simplify liveness/visibility code to read player location through the same entity-oriented path.
+- Simplify runtime-body views and body reconciliation helpers so the local player is a body kind distinction, not a second authoritative storage location.
+- Simplify context/query helpers to read player properties from the entity and player stats from `PlayerState`.
+
+#### Acceptance Criteria
+
+- local-player branching is limited to true semantic differences such as self sequencing or body identity
+- world helper code no longer contains storage-selection branches whose only purpose was mirroring
+- code complexity in movement/liveness/context is measurably lower by inspection and by branch count
+- `cargo test -p holtburger-world` passes
+- `cargo test -p holtburger-core` passes
+
+### Phase 5: Shrink And Clarify PlayerState
+
+#### Deliverables
+
+- Remove any now-dead `PlayerState` APIs that implied ownership of world/object state.
+- Rename fields, methods, and docs so `PlayerState` clearly means local-player/session state rather than a second world object.
+- Decide whether the type should remain `PlayerState` or be renamed to reflect its reduced role; API breakage is allowed.
+- Update `PlayerInfo`/event construction so player snapshots are assembled from the authoritative player entity plus local-player overlays without hidden duplication.
+
+#### Acceptance Criteria
+
+- `PlayerState` no longer advertises or behaves like a partial mirror of the player entity
+- docs/comments in world code describe one authoritative source for entity/object state
+- dead sync helpers and comments about mirroring are removed
+- cross-crate compile succeeds with the new ownership model
+
+### Phase 6: Verification And Cleanup Across Crates
+
+#### Deliverables
+
+- Retarget world, core, and CLI call sites to the new API surface.
+- Update or remove tests that were asserting the old mirrored behavior.
+- Add focused regression tests for self movement, property updates, visibility/liveness, derived stat reads, and player info emission.
+- Update architecture docs and any relevant plan docs that describe the old mirrored model.
+
+#### Acceptance Criteria
+
+- `cargo test -p holtburger-world` passes
+- `cargo test -p holtburger-core` passes
+- `cargo test -p holtburger-cli` passes
+- any workspace-wide targeted verification needed for downstream consumers passes
+
+## Risks & Mitigations
+
+### Risk: Self sequencing and self entity state get conflated during the refactor
+
+Mitigation:
+
+- keep sequence fields in `PlayerState` unless there is a clear reason to move them
+- treat sequencing as a separate design question from entity/object ownership
+
+### Risk: Runtime-body code still assumes `PlayerState.position` exists
+
+Mitigation:
+
+- introduce player-entity helper accessors before deleting fields
+- retarget runtime-body reads first, then remove mirrored fields
+
+### Risk: Player bootstrap ordering breaks once `PlayerState` stops carrying entity properties/position
+
+Mitigation:
+
+- materialize the player entity eagerly from `PlayerDescription`
+- treat bootstrap/order tests as a first-class acceptance gate before field deletion
+
+### Risk: Property-derived APIs on `PlayerState` hide more dependency surface than expected
+
+Mitigation:
+
+- move those APIs behind `WorldState` helpers before removing `HasProperties` from `PlayerState`
+- search the full workspace, not just `holtburger-world`, for direct property-derived player calls
+
+### Risk: Derived stats accidentally change because player property base values move
+
+Mitigation:
+
+- preserve current enchanted-property behavior and add regression coverage for representative stat/property reads
+- verify combat mode, level info, burden, armor, and resistance calculations after the migration
+
+### Risk: Inventory/equipment ownership logic quietly relies on player property mirroring
+
+Mitigation:
+
+- keep inventory/equipment ownership in `PlayerState`
+- audit container/wielder side effects while removing property mirroring
+
+### Risk: Cross-crate churn makes the refactor noisy and hard to land
+
+Mitigation:
+
+- centralize the new access pattern behind `WorldState` helpers first
+- make downstream call-site migration mechanical rather than ad hoc
+
+## Definition Of Done
+
+- the player entity is the only authoritative holder of player world/object state
+- `PlayerState` holds only local-player/session/derived state that does not belong on a generic entity
+- mirrored writes between player entity state and `PlayerState` have been removed
+- local-player branching is limited to genuine semantic differences rather than storage duplication
+- world/core/cli APIs are updated to the new ownership model without preserving obsolete compatibility shims
+- tests cover the major behavior surfaces touched by the refactor and pass
+
+## Living Worksheet
+
+### Task Checklist
+
+- [x] Phase 1: add player-entity helper accessors in `WorldState`
+- [x] Phase 1: add test helpers for local-player entity setup
+- [x] Phase 1: retarget world/core reads away from mirrored `PlayerState` fields
+- [x] Phase 2: make `PlayerDescription` bootstrap the player entity eagerly
+- [ ] Phase 3: move property-derived player APIs off `PlayerState`
+- [ ] Phase 3: remove `PlayerState.position`
+- [ ] Phase 3: remove `PlayerState.properties`
+- [ ] Phase 3: delete property mirroring in handlers/mutations
+- [ ] Phase 4: simplify movement/liveness/runtime-body special casing
+- [ ] Phase 5: trim or rename `PlayerState` APIs/docs
+- [ ] Phase 6: retarget downstream crates and tests
+- [ ] Final verification across world/core/cli
+
+### Decisions Log
+
+- API compatibility is not a constraint for this refactor.
+- The initial target is to eliminate duplicated world/object state, not to solve every self-sequencing concern in the same pass.
+- Inventory, equipment, spell knowledge, enchantments, and stat caches remain player-local until proven better on the entity.
+- Dry run conclusion: eager player-entity materialization during `PlayerDescription` is preferable to keeping any transitional bootstrap mirror for position/properties.
+- Dry run conclusion: `HasProperties` on `PlayerState` should be treated as an API migration item, not an implementation detail.
+- Phase 1 decision: `WorldState` now exposes first-class player-entity helpers (`player_entity`, `player_entity_mut`, `player_position`, `player_landblock`, `player_properties`) and production world/core movement reads should prefer that surface instead of touching mirrored `PlayerState` fields directly.
+- Phase 1 decision: those helpers still fall back to mirrored `PlayerState.position` / `PlayerState.properties` when the player entity is absent so Phase 1 can land before the Phase 2 bootstrap rewrite.
+- Phase 1 decision: test setup should prefer `seed_local_player_entity(...)` over open-coded `player.guid` + `player.position` + `entities.insert(...)` sequences when a local authoritative pose is required.
+- Phase 2 decision: `PlayerDescription` now eagerly creates or refreshes the player entity and writes bootstrap name/properties/position there first, before projecting player-facing events.
+- Phase 2 decision: `PlayerState::hydrate_from_player_description(...)` no longer seeds live player position directly; the authoritative bootstrap pose now comes from world-side entity setup.
+- Phase 2 decision: `PlayerState.properties` remains populated as a compatibility mirror for now because `get_level_info`, `emit_player_info`, and other property-derived APIs still depend on it. Removing that mirror remains Phase 3 work.
+
+### Progress Log
+
+- 2026-04-20: completed Phase 1 helper introduction and first production migration.
+- Landed `WorldState` player-entity/test-helper APIs and retargeted world runtime-body, liveness, movement-handler, and context reads to that helper surface.
+- Retargeted `holtburger-core` movement system production call sites away from direct `world.player.position` fallback reads.
+- Converted representative world/core movement tests to the new test helper so the supported setup path exists in code, not just in the plan.
+- Verification: `cargo test -p holtburger-world` passed and `cargo test -p holtburger-core` passed after the Phase 1 changes.
+- 2026-04-20: completed Phase 2 player-bootstrap migration.
+- Landed eager player-entity materialization/upsert during `PlayerDescription` handling and moved bootstrap name/property/position writes onto the player entity before `PlayerInfo`/level projection.
+- Stopped `PlayerState::hydrate_from_player_description(...)` from seeding live position directly; bootstrap pose is now synchronized from the authoritative entity path.
+- Retargeted world tests to assert that `PlayerDescription` creates the player entity eagerly and that the self `ObjectCreate` path still works when it arrives after that bootstrap entity already exists.
+- Verification: `cargo test -p holtburger-world` passed and `cargo test -p holtburger-core` passed after the Phase 2 changes.
+
+### Open Questions
+
+- Should self sequencing remain entirely on `PlayerState`, or should some of it move onto the player entity once the base ownership split is complete?
+- Should `PlayerInfoData` continue exposing `player_entity` as an embedded snapshot, or should it move to a more explicit composition model after the authority split lands?


### PR DESCRIPTION
This pull request primarily refactors how the player's entity and position are managed and synchronized between `PlayerState` and the world state, aiming to reduce redundancy and improve clarity. The changes also update related tests and documentation to reflect the new approach, and introduce some minor code formatting improvements.

Key changes include:

**Refactoring Player Entity and Position Management:**

* The player's entity is now consistently managed via a single authoritative entity in the world state, with `PlayerState` referencing it by GUID instead of duplicating position and other data. This reduces mirroring and potential inconsistencies. [[1]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bL684-R686) [[2]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bL726-R723) [[3]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bL760-R753) [[4]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bL778-R766) [[5]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bL1062-R1054) [[6]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aL514-L520)
* The helper method `seed_local_player_entity` is used throughout tests and client code to initialize the local player entity, ensuring consistent setup. [[1]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bL684-R686) [[2]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bL726-R723) [[3]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bL760-R753) [[4]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR1082-R1090) [[5]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR1122-R1130) [[6]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR1186-R1196) [[7]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR1252-R1262) [[8]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aL1336-R1342) [[9]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR1404-R1414)
* Player position is now accessed via `player_position()` instead of directly from `PlayerState`, reflecting the new authoritative source. [[1]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bL778-R766) [[2]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aL1439-R1444)

**Test and Documentation Updates:**

* Tests have been updated to use the new entity seeding and position access patterns, improving clarity and reducing duplication. [[1]](diffhunk://#diff-7a1c79e7436522393d8fc65f963b5fd813b527c6f14dc53b6ddb3fc9bb9502dcL47-R47) [[2]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR1082-R1090) [[3]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aL1110-R1108) [[4]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR1122-R1130) [[5]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR1186-R1196) [[6]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR1252-R1262) [[7]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aL1336-R1342) [[8]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aR1404-R1414) [[9]](diffhunk://#diff-5349ba0d5259d569f95fddda49501c9ad7e8e7cb2ab523a1d1f0fe53a7ad5a6aL1439-R1444)
* `TODO.md` is updated to mark the mirroring issue as addressed and clarify the status of related tasks.

**Minor Code Formatting and Cleanup:**

* Several code blocks and test setups have been reformatted for readability, including multi-line function calls and imports. [[1]](diffhunk://#diff-2caf446ea59f532c0ad08489c4839c9a9eabab32a133765128d197d2727ebe35L21-R22) [[2]](diffhunk://#diff-2caf446ea59f532c0ad08489c4839c9a9eabab32a133765128d197d2727ebe35L141-R137) [[3]](diffhunk://#diff-2caf446ea59f532c0ad08489c4839c9a9eabab32a133765128d197d2727ebe35L157-R153) [[4]](diffhunk://#diff-a7d8dbc188d98d08f4f269853a975545f0193d8fafafb73f286720deeb8dd3cbL38-R40) [[5]](diffhunk://#diff-a7d8dbc188d98d08f4f269853a975545f0193d8fafafb73f286720deeb8dd3cbL160-R164)

**Additional Test Coverage:**

* Tests now explicitly check for the authoritative player entity being spawned and for correct position synchronization, improving reliability. [[1]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bR1070) [[2]](diffhunk://#diff-129e8296f6c49ed9d5d6f55e7dbc7efaa31b2e756b888f33c191a5da21bbbd0bL1089-R1092)

These changes collectively improve the maintainability and correctness of player entity management in both runtime and test code.