### PR TITLE
Chore/harden 2

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,7 +98,6 @@ sequenceDiagram
     participant Content as ContentRepository
     participant Srv as Server (UDP)
     participant Sess as Session Layer
-    participant Proto as Protocol Layer
     participant Core as Core Engine
     participant World as World State
 
@@ -108,9 +107,8 @@ sequenceDiagram
 
     Srv->>Sess: Inbound Encrypted Bytes
     Sess->>Sess: Decrypt & Assemble Fragment Chunk
-    Sess->>Proto: Deserialize Buffer
-    Proto->>Sess: Unpacked GameMessage
-    Sess->>Core: Emit WireEvent (Raw Protocol)
+    Sess->>Core: Reassembled Message Bytes
+    Core->>Core: Decode GameMessage
     
     Core->>World: Issue Mutation Command (e.g., spawn, update vitals)
     World->>Core: Emit StateEvent (Authority Updated)
@@ -121,7 +119,6 @@ sequenceDiagram
 
 1. **Content (`content`)** discovers HBA sources, assembles `WorldBootstrap`, and exposes static lookup-oriented data to the frontend.
 2. **Networking (`session`)** tracks sequence numbers and decrypts data.
-3. **Parser (`protocol`)** turns data into Rust struct representations.
-4. **Engine (`core`)** coordinates protocol handling, movement execution, and world mutation requests.
-5. **Authority (`world`)** applies the mutation, preserves world invariants, and tells the engine what observably changed.
-6. **App (`cli`)** receives semantic deltas, updates mirrored read caches, and may query frontend-owned content or feed optional shared controllers with world-derived inputs before issuing new commands.
+3. **Engine (`core`)** decodes `GameMessage`, coordinates protocol handling, movement execution, and world mutation requests.
+4. **Authority (`world`)** applies the mutation, preserves world invariants, and tells the engine what observably changed.
+5. **App (`cli`)** receives semantic deltas, updates mirrored read caches, and may query frontend-owned content or feed optional shared controllers with world-derived inputs before issuing new commands.

--- a/TODO.md
+++ b/TODO.md
@@ -93,13 +93,13 @@
 - [x] Server messages being colored as errors, even though they aren't all errors.
 - [x] add deno_fetch.
 - [x] Get rid of noclip (dead code).
+- [x] `holtburger-core` abuses the shit out of WireEvents.
 - [~] All verbs should have equivalent slash chat commands.
 - [ ] Missing many unit tests for protocol types (lost in the refactor?).
 - [ ] Implement actual collisions.
 - [ ] Use sibling files for tests.
 - [ ] Exit combat when trying to craft? Combine action that isn't unlocking with a key?
 - [ ] `get_verbs() -> get_entities(self.selected_index)` pattern in tabs is inefficient because `get_entities()` is not cheap. We should store `selected_guid` when we update `selected_index` for tabs with entity content.
-- [ ] `holtburger-core` abuses the shit out of WireEvents.
 - [ ] should really prefix server vs client messages. There are some messages that are bi-directional and confusing.
 - [ ] Emotes.
 - [ ] Some equipment swapping jank going on.

--- a/TODO.md
+++ b/TODO.md
@@ -91,6 +91,8 @@
 - [x] PlayerState and entities mirroring in `WorldState` is annoying.
     - [x] Keep non-entity stuff in PlayerState and store an entity GUID there instead?
 - [x] Server messages being colored as errors, even though they aren't all errors.
+- [x] add deno_fetch.
+- [x] Get rid of noclip (dead code).
 - [~] All verbs should have equivalent slash chat commands.
 - [ ] Missing many unit tests for protocol types (lost in the refactor?).
 - [ ] Implement actual collisions.
@@ -101,9 +103,7 @@
 - [ ] should really prefix server vs client messages. There are some messages that are bi-directional and confusing.
 - [ ] Emotes.
 - [ ] Some equipment swapping jank going on.
-- [ ] Get rid of noclip (dead code).
 - [ ] Speed up TUI rendering.
-- [ ] add deno_fetch.
 
 ### High
 - [x] Fail when spell/attack distance is too far.
@@ -268,7 +268,7 @@
 - [x] Client sending duplicate packets to server.
 - [x] Add all spells causes a sequence error.
 - [x] Add `/run <ARGS>` command.
-- [~] Mage script improvements:
+- [x] Mage script improvements:
     - [x] Add preferred spell IDs.
     - [x] Fix not using revitalize.
     - [x] Snap to target heading before casting?

--- a/apps/holtburger-cli/src/pages/game/data.rs
+++ b/apps/holtburger-cli/src/pages/game/data.rs
@@ -303,8 +303,6 @@ pub struct GameData {
     pub combat_runtime: CombatRuntimeState,
     /// Local CLI combat controls for melee power or missile accuracy and attack height.
     pub combat_controls: CombatControlState,
-    /// Whether we can walk through walls (debug feature).
-    pub noclip: bool,
     /// Every entity currently in player's pack.
     pub inventory: HashSet<Guid>,
     /// Map of GUIDs currently equipped on the character.
@@ -346,7 +344,6 @@ impl Default for GameData {
             combat_mode: CombatMode::NonCombat,
             combat_runtime: CombatRuntimeState::default(),
             combat_controls: CombatControlState::default(),
-            noclip: false,
             inventory: HashSet::new(),
             equipment: HashMap::new(),
             trade: None,

--- a/apps/holtburger-cli/src/pages/game/domains/navigation.rs
+++ b/apps/holtburger-cli/src/pages/game/domains/navigation.rs
@@ -107,14 +107,6 @@ pub(super) fn reduce_view_event(state: &mut GameState, event: &ClientViewEvent) 
             object_interaction::refresh_context_buffer(state);
             result.request_redraw(RedrawPriority::Immediate);
         }
-        ClientViewEvent::NoClipUpdated { enabled } => {
-            state.data.noclip = *enabled;
-            let status = if *enabled { "ENABLED" } else { "DISABLED" };
-            result.actions.push(AppAction::Log {
-                chat_tags: ChatMessageTags::system(),
-                message: format!(">> NoClip is now {}", status),
-            });
-        }
         ClientViewEvent::TeleportStarted { .. } => {}
         _ => {}
     }

--- a/crates/holtburger-core/ARCHITECTURE.md
+++ b/crates/holtburger-core/ARCHITECTURE.md
@@ -15,16 +15,17 @@ The top-level entry point. It instantiates the `Session` (networking) from `holt
 To instantiate a client, we use the `ClientBuilder` ([src/client/builder.rs](src/client/builder.rs)). This configures credentials, server endpoints, optional debug features, and runtime asset loading. `ClientRuntimeBuilder::load_assets(&ContentRepository)` is where the builder reads the specific startup assets it needs and assembles `WorldBootstrap`.
 
 #### Event Streams
-We use a 3-layer event model to separate protocol fidelity from UI ergonomics, solving the monolithic object-cloning problem via highly granular Delta Events:
+We use a narrow runtime surface that keeps protocol and UI concerns distinct without inventing an extra public bus:
 
-1. **`WireEvent`** (Protocol): 1:1 raw packet semantics from `holtburger-session`. Used for logging, debugging, or deep client control.
+1. **Session bytes / decoded `GameMessage`**: `holtburger-session` hands reassembled payload bytes to core, and core decodes them into protocol types at the core-to-world boundary.
 2. **`WorldEvent`** (World): World-layer events emitted by `holtburger-world`, including authoritative mutations and packet-scoped processing outcomes.
-3. **`WorldViewEvent`** ([src/client/types.rs](src/client/types.rs)): The unified semantic delta-event feed. The core listens to incoming `WireEvent`s and `WorldEvent`s and collapses them onto THIS SINGLE CHANNEL line.
-   - Consumers (like `holtburger-cli`) **ONLY** subscribe to `WorldViewEvent` because it is lightweight. It broadcasts granular semantic delta-events (like `PropertyUpdated { guid, update }`) instead of massive `Box<Entity>` clones.
+3. **`ClientViewEvent`** ([src/client/types.rs](src/client/types.rs)): The unified semantic delta-event feed exposed to frontends, scripts, and harnesses.
+    - Consumers (like `holtburger-cli`) subscribe to `ClientViewEvent` because it broadcasts granular semantic deltas (like `PropertyUpdated { guid, update }`) instead of massive `Box<Entity>` clones.
+    - Low-level raw packet dumping, when needed for diagnostics, is configured explicitly through `ClientRuntimeBuilder::message_dump_dir(...)` instead of a general-purpose runtime event bus.
 
 #### Interaction
 - **ClientCommand**: Commands sent from the UI to the engine (e.g., `DriveMovement`, `Use`). Handled in [src/client/commands.rs](src/client/commands.rs).
-- **Producer-Only Pattern**: The Core Engine is strictly *producer-only* for the event streams. It never consumes its own broadcast events internally (that would introduce latency and state drift). It uses synchronous direct logic to move from Wire -> State -> View.
+- **Producer-Only Pattern**: The Core Engine is strictly *producer-only* for the public event streams. It never consumes its own broadcast events internally (that would introduce latency and state drift). It uses synchronous direct logic to move from decoded protocol -> state -> view.
 
 ### Command and Controller Boundary
 
@@ -138,20 +139,21 @@ sequenceDiagram
     participant Net as Session (UDP Transport)
     participant Core as Client Engine (Orchestrator)
     participant World as WorldState (Data Authority)
-    participant View as WorldViewEvent (Delta Stream)
+    participant View as ClientViewEvent (Delta Stream)
     participant UI as Consumer (TUI/Local Projection)
 
-    Net->>Core: WireEvent (Unpacked Packet)
+    Net->>Core: Reassembled Message Bytes
+    Core->>Core: Decode GameMessage
     Core->>World: Mutate Authority (e.g. Spawn)
     World->>Core: WorldEvent (e.g EntitySpawned)
     Core->>View: Emit as Semantic Delta
     View->>UI: Process In-Place Projection Update
 ```
 
-1. **Networking**: `holtburger-session` parses UDP packets.
-2. **Engine**: `Client` processes the `WireEvent` and emits intents to `holtburger-world`'s `WorldState`.
+1. **Networking**: `holtburger-session` reassembles decrypted UDP payloads.
+2. **Engine**: `Client` decodes `GameMessage`, performs any core-owned handling, and emits intents to `holtburger-world`'s `WorldState`.
 3. **Authority**: `WorldState` performs the mutation and emits a `WorldEvent`.
-4. **Projection**: `Client` translates the `WorldEvent` directly into a granular `WorldViewEvent` delta snapshot.
+4. **Projection**: `Client` translates decoded protocol handling and `WorldEvent` output directly into granular `ClientViewEvent` deltas.
 5. **UI**: Consumers receive the delta and mutate their local cached models safely without lock contention (`Arc<RwLock>`) or massive memory allocations.
 
 ## 🛠️ Developer Onboarding
@@ -161,7 +163,7 @@ sequenceDiagram
 2. **Update Protocol**: Add the message structure to `holtburger-protocol`.
 3. **Handle in Core**: Add a case to the core loop in [src/client/messages.rs](src/client/messages.rs).
 4. **Update State**: If the message changes the world, add a method to `holtburger-world` and emit a `WorldEvent`.
-5. **Map to View**: Update the `WorldViewEvent` stream in `emit_wire_event` or `emit_world_view_projection` inside [src/client/mod.rs](src/client/mod.rs) to share the new delta with the UI.
+5. **Map to View**: Update the direct `ClientViewEvent` emission in [src/client/messages.rs](src/client/messages.rs) or `emit_world_view_projection` inside [src/client/mod.rs](src/client/mod.rs) to share the new delta with the UI.
 
 ### Adding or Refactoring a Reusable Controller
 1. **Prove the behavior is shared**: Confirm that the behavior is likely useful across multiple clients or modes of control.

--- a/crates/holtburger-core/src/client/builder.rs
+++ b/crates/holtburger-core/src/client/builder.rs
@@ -85,7 +85,22 @@ impl ClientRuntimeBuilder {
         self
     }
 
+    fn ensure_message_dump_dir(&self) -> Result<()> {
+        if let Some(path) = &self.message_dump_dir {
+            std::fs::create_dir_all(path).with_context(|| {
+                format!(
+                    "failed to create message dump directory: {}",
+                    path.display()
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+
     pub async fn connect(self) -> Result<ClientRuntime> {
+        self.ensure_message_dump_dir()?;
+
         let endpoint = self.server_endpoint.clone().ok_or_else(|| {
             anyhow!("ClientRuntimeBuilder requires a server endpoint before connect()")
         })?;
@@ -108,6 +123,7 @@ impl ClientRuntimeBuilder {
 
     #[cfg(test)]
     pub(crate) fn build_with_session(self, session: Session) -> Result<ClientRuntime> {
+        self.ensure_message_dump_dir()?;
         self.finish(session)
     }
 

--- a/crates/holtburger-core/src/client/builder.rs
+++ b/crates/holtburger-core/src/client/builder.rs
@@ -3,6 +3,7 @@ use holtburger_content::ContentRepository;
 use holtburger_dat::file_type::{MotionKinematics, SkillTable, SpellTable, XpTable};
 use holtburger_session::Session;
 use holtburger_world::{BasicSpatialPhysics, SpatialPhysics, WorldBootstrap, WorldState};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
@@ -23,6 +24,7 @@ pub struct ClientRuntimeBuilder {
     server_endpoint: Option<ServerEndpoint>,
     world_bootstrap: Option<Arc<WorldBootstrap>>,
     spatial_physics: Option<Arc<dyn SpatialPhysics>>,
+    message_dump_dir: Option<PathBuf>,
 }
 
 impl ClientRuntimeBuilder {
@@ -32,6 +34,7 @@ impl ClientRuntimeBuilder {
             server_endpoint: None,
             world_bootstrap: None,
             spatial_physics: None,
+            message_dump_dir: None,
         }
     }
 
@@ -77,6 +80,11 @@ impl ClientRuntimeBuilder {
         self
     }
 
+    pub fn message_dump_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.message_dump_dir = Some(path.into());
+        self
+    }
+
     pub async fn connect(self) -> Result<ClientRuntime> {
         let endpoint = self.server_endpoint.clone().ok_or_else(|| {
             anyhow!("ClientRuntimeBuilder requires a server endpoint before connect()")
@@ -111,7 +119,6 @@ impl ClientRuntimeBuilder {
             .spatial_physics
             .unwrap_or_else(|| Arc::new(BasicSpatialPhysics));
 
-        let (wire_event_tx, _) = broadcast::channel(1024);
         let (client_view_event_tx, _) = broadcast::channel(4096);
 
         Ok(ClientRuntime {
@@ -120,10 +127,9 @@ impl ClientRuntimeBuilder {
             active_confirmation: None,
             active_busy_operation: None,
             state: ClientState::Connected,
-            wire_event_tx,
             client_view_event_tx,
             command_rx: None,
-            message_dump_dir: None,
+            message_dump_dir: self.message_dump_dir,
             message_counter: 0,
             movement: MovementSystem::new(),
             simulation: ClientSimulationSystem::new(),
@@ -135,7 +141,6 @@ impl ClientRuntimeBuilder {
 
 #[cfg(test)]
 pub(crate) fn build_test_client(initial_state: ClientState) -> ClientRuntime {
-    let (wire_event_tx, _) = broadcast::channel(1024);
     let (client_view_event_tx, _) = broadcast::channel(4096);
 
     let mut client = ClientRuntime {
@@ -144,7 +149,6 @@ pub(crate) fn build_test_client(initial_state: ClientState) -> ClientRuntime {
         active_confirmation: None,
         active_busy_operation: None,
         state: ClientState::Connected,
-        wire_event_tx,
         client_view_event_tx,
         command_rx: None,
         message_dump_dir: None,

--- a/crates/holtburger-core/src/client/commands.rs
+++ b/crates/holtburger-core/src/client/commands.rs
@@ -1231,8 +1231,8 @@ mod tests {
     use super::{NormalizedSpellCast, normalize_spell_cast};
     use crate::client::builder;
     use crate::client::types::{
-        ActiveCharacterConfirmation, BusyOperationKind, CharacterManagementOperation,
-        ActionResultReason, ActionResultSource, ClientCommand, ClientViewEvent,
+        ActionResultReason, ActionResultSource, ActiveCharacterConfirmation, BusyOperationKind,
+        CharacterManagementOperation, ClientCommand, ClientViewEvent,
     };
     use crate::client::{ClientRuntime, ClientState};
     use holtburger_common::position::WorldPosition;

--- a/crates/holtburger-core/src/client/commands.rs
+++ b/crates/holtburger-core/src/client/commands.rs
@@ -1,4 +1,6 @@
-use crate::client::types::{BusyOperationKind, ClientCommand, TargetSlot, WireEvent};
+use crate::client::types::{
+    ActionResultReason, ActionResultSource, BusyOperationKind, ClientCommand, TargetSlot,
+};
 use crate::client::{ClientRuntime, ClientState};
 use anyhow::{Result, anyhow};
 use holtburger_common::CharacterOption;
@@ -316,10 +318,13 @@ impl ClientRuntime {
                             .await;
                     }
 
-                    self.emit_wire_event(WireEvent::ClientError(format!(
-                        "No supported chat transport is available for {:?}.",
-                        channel
-                    )));
+                    self.emit_action_result(
+                        ActionResultSource::Client,
+                        ActionResultReason::General(format!(
+                            "No supported chat transport is available for {:?}.",
+                            channel
+                        )),
+                    );
                 }
                 Ok(())
             }
@@ -622,9 +627,12 @@ impl ClientRuntime {
             }
             ClientCommand::RespondToConfirmation { accepted } => {
                 let Some(confirmation) = self.active_confirmation.clone() else {
-                    self.emit_wire_event(WireEvent::ClientError(
-                        "No active confirmation request to answer.".to_string(),
-                    ));
+                    self.emit_action_result(
+                        ActionResultSource::Client,
+                        ActionResultReason::General(
+                            "No active confirmation request to answer.".to_string(),
+                        ),
+                    );
                     return Ok(());
                 };
 
@@ -1025,7 +1033,7 @@ impl ClientRuntime {
             }
             ClientCommand::ShowPartyStatus => {
                 for line in self.format_party_status_lines() {
-                    self.emit_wire_event(WireEvent::LogMessage(line));
+                    self.emit_log_message(line);
                 }
                 Ok(())
             }
@@ -1224,7 +1232,7 @@ mod tests {
     use crate::client::builder;
     use crate::client::types::{
         ActiveCharacterConfirmation, BusyOperationKind, CharacterManagementOperation,
-        ClientCommand, ClientViewEvent, WireEvent,
+        ActionResultReason, ActionResultSource, ClientCommand, ClientViewEvent,
     };
     use crate::client::{ClientRuntime, ClientState};
     use holtburger_common::position::WorldPosition;
@@ -1801,7 +1809,7 @@ mod tests {
                 },
             }],
         });
-        let mut wire_events = client.subscribe_wire_events();
+        let mut view_events = client.subscribe_client_view_events();
 
         client
             .handle_command(ClientCommand::ShowPartyStatus)
@@ -1809,8 +1817,8 @@ mod tests {
             .unwrap();
 
         let mut log_lines = Vec::new();
-        while let Ok(event) = wire_events.try_recv() {
-            if let WireEvent::LogMessage(line) = event {
+        while let Ok(event) = view_events.try_recv() {
+            if let ClientViewEvent::LogMessage(line) = event {
                 log_lines.push(line);
             }
         }
@@ -1834,6 +1842,34 @@ mod tests {
                 .any(|line| line == "Departed members tracked: 1")
         );
         assert!(log_lines.iter().any(|line| line == "Locks: Leader Lock"));
+    }
+
+    #[tokio::test]
+    async fn respond_to_confirmation_without_active_request_emits_client_action_result() {
+        let mut client = build_test_client();
+        let mut view_events = client.subscribe_client_view_events();
+
+        client
+            .handle_command(ClientCommand::RespondToConfirmation { accepted: true })
+            .await
+            .unwrap();
+
+        let mut saw_result = false;
+        while let Ok(event) = view_events.try_recv() {
+            if let ClientViewEvent::ActionResult { source, reason } = event {
+                assert_eq!(source, ActionResultSource::Client);
+                assert_eq!(
+                    reason,
+                    ActionResultReason::General(
+                        "No active confirmation request to answer.".to_string(),
+                    )
+                );
+                saw_result = true;
+                break;
+            }
+        }
+
+        assert!(saw_result);
     }
 
     #[tokio::test]

--- a/crates/holtburger-core/src/client/messages.rs
+++ b/crates/holtburger-core/src/client/messages.rs
@@ -278,60 +278,62 @@ impl ClientRuntime {
                     Ok(())
                 }
                 GameEvent::AttackDone(data) => {
-                    let feedback =
-                        crate::client::types::CombatFeedback::AttackDone { error: data.error };
                     let _ = self
                         .client_view_event_tx
-                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
+                        .send(ClientViewEvent::CombatFeedback(
+                            crate::client::types::CombatFeedback::AttackDone { error: data.error },
+                        ));
                     Ok(())
                 }
                 GameEvent::AttackerNotification(data) => {
-                    let feedback = crate::client::types::CombatFeedback::AttackerNotification {
-                        defender_name: data.defender_name.clone(),
-                        damage_type: data.damage_type,
-                        health_percent: data.health_percent,
-                        damage: data.damage,
-                        critical_hit: data.critical_hit,
-                        attack_conditions: data.attack_conditions,
-                    };
                     let _ = self
                         .client_view_event_tx
-                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
+                        .send(ClientViewEvent::CombatFeedback(
+                            crate::client::types::CombatFeedback::AttackerNotification {
+                                defender_name: data.defender_name.clone(),
+                                damage_type: data.damage_type,
+                                health_percent: data.health_percent,
+                                damage: data.damage,
+                                critical_hit: data.critical_hit,
+                                attack_conditions: data.attack_conditions,
+                            },
+                        ));
                     Ok(())
                 }
                 GameEvent::DefenderNotification(data) => {
-                    let feedback = crate::client::types::CombatFeedback::DefenderNotification {
-                        attacker_name: data.attacker_name.clone(),
-                        damage_type: data.damage_type,
-                        health_percent: data.health_percent,
-                        damage: data.damage,
-                        damage_location: data.damage_location,
-                        critical_hit: data.critical_hit,
-                        attack_conditions: data.attack_conditions,
-                    };
                     let _ = self
                         .client_view_event_tx
-                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
+                        .send(ClientViewEvent::CombatFeedback(
+                            crate::client::types::CombatFeedback::DefenderNotification {
+                                attacker_name: data.attacker_name.clone(),
+                                damage_type: data.damage_type,
+                                health_percent: data.health_percent,
+                                damage: data.damage,
+                                damage_location: data.damage_location,
+                                critical_hit: data.critical_hit,
+                                attack_conditions: data.attack_conditions,
+                            },
+                        ));
                     Ok(())
                 }
                 GameEvent::EvasionAttackerNotification(data) => {
-                    let feedback =
-                        crate::client::types::CombatFeedback::EvasionAttackerNotification {
-                            defender_name: data.defender_name.clone(),
-                        };
                     let _ = self
                         .client_view_event_tx
-                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
+                        .send(ClientViewEvent::CombatFeedback(
+                            crate::client::types::CombatFeedback::EvasionAttackerNotification {
+                                defender_name: data.defender_name.clone(),
+                            },
+                        ));
                     Ok(())
                 }
                 GameEvent::EvasionDefenderNotification(data) => {
-                    let feedback =
-                        crate::client::types::CombatFeedback::EvasionDefenderNotification {
-                            attacker_name: data.attacker_name.clone(),
-                        };
                     let _ = self
                         .client_view_event_tx
-                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
+                        .send(ClientViewEvent::CombatFeedback(
+                            crate::client::types::CombatFeedback::EvasionDefenderNotification {
+                                attacker_name: data.attacker_name.clone(),
+                            },
+                        ));
                     Ok(())
                 }
                 GameEvent::CombatCommenceAttack => {
@@ -343,21 +345,23 @@ impl ClientRuntime {
                     Ok(())
                 }
                 GameEvent::VictimNotification(data) => {
-                    let feedback = crate::client::types::CombatFeedback::VictimNotification {
-                        death_message: data.death_message.clone(),
-                    };
                     let _ = self
                         .client_view_event_tx
-                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
+                        .send(ClientViewEvent::CombatFeedback(
+                            crate::client::types::CombatFeedback::VictimNotification {
+                                death_message: data.death_message.clone(),
+                            },
+                        ));
                     Ok(())
                 }
                 GameEvent::KillerNotification(data) => {
-                    let feedback = crate::client::types::CombatFeedback::KillerNotification {
-                        death_message: data.death_message.clone(),
-                    };
                     let _ = self
                         .client_view_event_tx
-                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
+                        .send(ClientViewEvent::CombatFeedback(
+                            crate::client::types::CombatFeedback::KillerNotification {
+                                death_message: data.death_message.clone(),
+                            },
+                        ));
                     Ok(())
                 }
                 GameEvent::WeenieError(data) => {
@@ -465,14 +469,15 @@ impl ClientRuntime {
                 Ok(())
             }
             GameMessage::PlayerKilled(data) => {
-                let feedback = crate::client::types::CombatFeedback::PlayerKilled {
-                    death_message: data.death_message.clone(),
-                    victim_id: data.victim_id,
-                    killer_id: data.killer_id,
-                };
                 let _ = self
                     .client_view_event_tx
-                    .send(ClientViewEvent::CombatFeedback(feedback.clone()));
+                    .send(ClientViewEvent::CombatFeedback(
+                        crate::client::types::CombatFeedback::PlayerKilled {
+                            death_message: data.death_message.clone(),
+                            victim_id: data.victim_id,
+                            killer_id: data.killer_id,
+                        },
+                    ));
                 Ok(())
             }
             GameMessage::PlayerTeleport(data) => {

--- a/crates/holtburger-core/src/client/messages.rs
+++ b/crates/holtburger-core/src/client/messages.rs
@@ -157,19 +157,21 @@ impl ClientRuntime {
                 self.state =
                     ClientState::CharacterSelection(self.character_selection.characters.clone());
                 self.send_status_event();
-                let _ = self.client_view_event_tx.send(ClientViewEvent::CharacterList(
-                    self.character_selection.characters.clone(),
-                ));
+                let _ = self
+                    .client_view_event_tx
+                    .send(ClientViewEvent::CharacterList(
+                        self.character_selection.characters.clone(),
+                    ));
                 Ok(())
             }
             GameMessage::CharacterCreateResponse(data) => {
                 let operation = self.character_selection.take_pending_character_operation();
-                let _ = self.client_view_event_tx.send(
-                    ClientViewEvent::CharacterManagementResponse {
-                        operation,
-                        response: (*data).clone(),
-                    },
-                );
+                let _ =
+                    self.client_view_event_tx
+                        .send(ClientViewEvent::CharacterManagementResponse {
+                            operation,
+                            response: (*data).clone(),
+                        });
                 Ok(())
             }
             GameMessage::CharacterDeleteResponse => {
@@ -196,7 +198,9 @@ impl ClientRuntime {
                     Ok(())
                 }
                 GameEvent::PingResponse(_) => {
-                    let _ = self.client_view_event_tx.send(ClientViewEvent::PingResponse);
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::PingResponse);
                     Ok(())
                 }
                 GameEvent::ViewContents(_data) => Ok(()),
@@ -208,11 +212,13 @@ impl ClientRuntime {
                     Ok(())
                 }
                 GameEvent::ChannelBroadcast(data) => {
-                    let _ = self.client_view_event_tx.send(ClientViewEvent::ChannelMessage {
-                        channel: ChatChannelInfo::legacy(data.channel),
-                        sender: data.sender_name.clone(),
-                        message: data.message.clone(),
-                    });
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::ChannelMessage {
+                            channel: ChatChannelInfo::legacy(data.channel),
+                            sender: data.sender_name.clone(),
+                            message: data.message.clone(),
+                        });
                     Ok(())
                 }
                 GameEvent::SetTurbineChatChannels(data) => {
@@ -220,10 +226,12 @@ impl ClientRuntime {
                     Ok(())
                 }
                 GameEvent::PopupString(data) => {
-                    let _ = self.client_view_event_tx.send(ClientViewEvent::ServerMessage {
-                        message: data.message.clone(),
-                        chat_type: (ChatMessageType::System as u32).into(),
-                    });
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::ServerMessage {
+                            message: data.message.clone(),
+                            chat_type: (ChatMessageType::System as u32).into(),
+                        });
                     Ok(())
                 }
                 GameEvent::CharacterConfirmationRequest(data) => {
@@ -261,16 +269,17 @@ impl ClientRuntime {
                     Ok(())
                 }
                 GameEvent::CommunicationTransientString(data) => {
-                    let _ = self.client_view_event_tx.send(ClientViewEvent::ServerMessage {
-                        message: data.message.clone(),
-                        chat_type: (ChatMessageType::System as u32).into(),
-                    });
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::ServerMessage {
+                            message: data.message.clone(),
+                            chat_type: (ChatMessageType::System as u32).into(),
+                        });
                     Ok(())
                 }
                 GameEvent::AttackDone(data) => {
-                    let feedback = crate::client::types::CombatFeedback::AttackDone {
-                        error: data.error,
-                    };
+                    let feedback =
+                        crate::client::types::CombatFeedback::AttackDone { error: data.error };
                     let _ = self
                         .client_view_event_tx
                         .send(ClientViewEvent::CombatFeedback(feedback.clone()));
@@ -306,27 +315,31 @@ impl ClientRuntime {
                     Ok(())
                 }
                 GameEvent::EvasionAttackerNotification(data) => {
-                    let feedback = crate::client::types::CombatFeedback::EvasionAttackerNotification {
-                        defender_name: data.defender_name.clone(),
-                    };
+                    let feedback =
+                        crate::client::types::CombatFeedback::EvasionAttackerNotification {
+                            defender_name: data.defender_name.clone(),
+                        };
                     let _ = self
                         .client_view_event_tx
                         .send(ClientViewEvent::CombatFeedback(feedback.clone()));
                     Ok(())
                 }
                 GameEvent::EvasionDefenderNotification(data) => {
-                    let feedback = crate::client::types::CombatFeedback::EvasionDefenderNotification {
-                        attacker_name: data.attacker_name.clone(),
-                    };
+                    let feedback =
+                        crate::client::types::CombatFeedback::EvasionDefenderNotification {
+                            attacker_name: data.attacker_name.clone(),
+                        };
                     let _ = self
                         .client_view_event_tx
                         .send(ClientViewEvent::CombatFeedback(feedback.clone()));
                     Ok(())
                 }
                 GameEvent::CombatCommenceAttack => {
-                    let _ = self.client_view_event_tx.send(ClientViewEvent::CombatFeedback(
-                        crate::client::types::CombatFeedback::AttackCommenced,
-                    ));
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::CombatFeedback(
+                            crate::client::types::CombatFeedback::AttackCommenced,
+                        ));
                     Ok(())
                 }
                 GameEvent::VictimNotification(data) => {
@@ -396,10 +409,12 @@ impl ClientRuntime {
                         .map(|e: &Entity| e.name().to_string())
                         .unwrap_or_else(|| format!("0x{:08X}", partner_guid.0));
                     let message = format!("Trade started with {}.", partner_name);
-                    let _ = self.client_view_event_tx.send(ClientViewEvent::ServerMessage {
-                        message: message.clone(),
-                        chat_type: (ChatMessageType::System as u32).into(),
-                    });
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::ServerMessage {
+                            message: message.clone(),
+                            chat_type: (ChatMessageType::System as u32).into(),
+                        });
                     Ok(())
                 }
                 GameEvent::QueryItemManaResponse(data) => {
@@ -438,10 +453,12 @@ impl ClientRuntime {
                         }
                     });
 
-                let _ = self.client_view_event_tx.send(ClientViewEvent::PlayerEntered {
-                    guid: player_id,
-                    name: name.clone(),
-                });
+                let _ = self
+                    .client_view_event_tx
+                    .send(ClientViewEvent::PlayerEntered {
+                        guid: player_id,
+                        name: name.clone(),
+                    });
 
                 self.send_login_complete().await?;
                 self.enter_world().await?;
@@ -471,10 +488,12 @@ impl ClientRuntime {
             }
             GameMessage::GameAction(data) => self.handle_game_action(&data.action).await,
             GameMessage::ServerMessage(data) => {
-                let _ = self.client_view_event_tx.send(ClientViewEvent::ServerMessage {
-                    message: data.message.clone(),
-                    chat_type: data.chat_type.into(),
-                });
+                let _ = self
+                    .client_view_event_tx
+                    .send(ClientViewEvent::ServerMessage {
+                        message: data.message.clone(),
+                        chat_type: data.chat_type.into(),
+                    });
                 Ok(())
             }
             GameMessage::CharacterError(data) => {
@@ -551,11 +570,13 @@ impl ClientRuntime {
                 {
                     let channel_info =
                         ChatChannelInfo::turbine(*channel, *chat_type, data.dispatch_type);
-                    let _ = self.client_view_event_tx.send(ClientViewEvent::ChannelMessage {
-                        channel: channel_info,
-                        sender: sender_name.clone(),
-                        message: message.clone(),
-                    });
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::ChannelMessage {
+                            channel: channel_info,
+                            sender: sender_name.clone(),
+                            message: message.clone(),
+                        });
                 }
                 Ok(())
             }

--- a/crates/holtburger-core/src/client/messages.rs
+++ b/crates/holtburger-core/src/client/messages.rs
@@ -2,6 +2,7 @@ use super::{ClientRuntime, types::*};
 use anyhow::Result;
 use holtburger_common::ConfirmationType;
 use holtburger_common::properties::WorldObjectExt as _;
+use holtburger_protocol::errors::WeenieError;
 use holtburger_protocol::messages::*;
 use holtburger_protocol::traits::ProtocolUnpack;
 use holtburger_world::RuntimeBodyResetCause;
@@ -99,8 +100,6 @@ impl ClientRuntime {
     }
 
     pub(super) async fn handle_message(&mut self, data: &[u8]) -> Result<Vec<WorldEvent>> {
-        self.emit_wire_event(WireEvent::RawMessage(data.to_vec()));
-
         if let Some(ref dump_dir) = self.message_dump_dir {
             let path = dump_dir.join(format!("{:05}.bin", self.message_counter));
             std::fs::write(path, data)?;
@@ -128,7 +127,11 @@ impl ClientRuntime {
 
         log::debug!("GameMessage: {:?}", message);
 
-        self.emit_wire_event(WireEvent::GameMessage(Box::new(message.clone())));
+        if let GameMessage::ServerName(data) = &message {
+            let _ = self
+                .client_view_event_tx
+                .send(ClientViewEvent::WorldNameUpdated(data.name.clone()));
+        }
 
         // Pass to world state for tracking positioning and spawning
         let world_events = self.world.handle_message(&message);
@@ -154,22 +157,26 @@ impl ClientRuntime {
                 self.state =
                     ClientState::CharacterSelection(self.character_selection.characters.clone());
                 self.send_status_event();
-                self.emit_wire_event(WireEvent::CharacterList(
+                let _ = self.client_view_event_tx.send(ClientViewEvent::CharacterList(
                     self.character_selection.characters.clone(),
                 ));
                 Ok(())
             }
             GameMessage::CharacterCreateResponse(data) => {
                 let operation = self.character_selection.take_pending_character_operation();
-                self.emit_wire_event(WireEvent::CharacterManagementResponse {
-                    operation,
-                    response: (*data).clone(),
-                });
+                let _ = self.client_view_event_tx.send(
+                    ClientViewEvent::CharacterManagementResponse {
+                        operation,
+                        response: (*data).clone(),
+                    },
+                );
                 Ok(())
             }
             GameMessage::CharacterDeleteResponse => {
                 self.character_selection.take_pending_character_operation();
-                self.emit_wire_event(WireEvent::CharacterDeleteResponse);
+                let _ = self
+                    .client_view_event_tx
+                    .send(ClientViewEvent::CharacterDeleteResponse);
                 Ok(())
             }
             GameMessage::CharacterEnterWorldServerReady => {
@@ -189,25 +196,19 @@ impl ClientRuntime {
                     Ok(())
                 }
                 GameEvent::PingResponse(_) => {
-                    self.emit_wire_event(WireEvent::PingResponse);
+                    let _ = self.client_view_event_tx.send(ClientViewEvent::PingResponse);
                     Ok(())
                 }
-                GameEvent::ViewContents(data) => {
-                    self.emit_wire_event(WireEvent::ViewContents {
-                        container: data.container,
-                        items: data.items.clone(),
-                    });
-                    Ok(())
-                }
+                GameEvent::ViewContents(_data) => Ok(()),
                 GameEvent::Tell(data) => {
-                    self.emit_wire_event(WireEvent::Tell {
+                    let _ = self.client_view_event_tx.send(ClientViewEvent::Tell {
                         sender: data.sender_name.clone(),
                         message: data.message.clone(),
                     });
                     Ok(())
                 }
                 GameEvent::ChannelBroadcast(data) => {
-                    self.emit_wire_event(WireEvent::ChannelMessage {
+                    let _ = self.client_view_event_tx.send(ClientViewEvent::ChannelMessage {
                         channel: ChatChannelInfo::legacy(data.channel),
                         sender: data.sender_name.clone(),
                         message: data.message.clone(),
@@ -219,9 +220,9 @@ impl ClientRuntime {
                     Ok(())
                 }
                 GameEvent::PopupString(data) => {
-                    self.emit_wire_event(WireEvent::ServerMessage {
+                    let _ = self.client_view_event_tx.send(ClientViewEvent::ServerMessage {
                         message: data.message.clone(),
-                        chat_type: ChatMessageType::System as u32,
+                        chat_type: (ChatMessageType::System as u32).into(),
                     });
                     Ok(())
                 }
@@ -260,109 +261,126 @@ impl ClientRuntime {
                     Ok(())
                 }
                 GameEvent::CommunicationTransientString(data) => {
-                    self.emit_wire_event(WireEvent::ServerMessage {
+                    let _ = self.client_view_event_tx.send(ClientViewEvent::ServerMessage {
                         message: data.message.clone(),
-                        chat_type: ChatMessageType::System as u32,
+                        chat_type: (ChatMessageType::System as u32).into(),
                     });
                     Ok(())
                 }
                 GameEvent::AttackDone(data) => {
-                    self.emit_wire_event(WireEvent::CombatFeedback(
-                        crate::client::types::CombatFeedback::AttackDone { error: data.error },
-                    ));
+                    let feedback = crate::client::types::CombatFeedback::AttackDone {
+                        error: data.error,
+                    };
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
                     Ok(())
                 }
                 GameEvent::AttackerNotification(data) => {
-                    self.emit_wire_event(WireEvent::CombatFeedback(
-                        crate::client::types::CombatFeedback::AttackerNotification {
-                            defender_name: data.defender_name.clone(),
-                            damage_type: data.damage_type,
-                            health_percent: data.health_percent,
-                            damage: data.damage,
-                            critical_hit: data.critical_hit,
-                            attack_conditions: data.attack_conditions,
-                        },
-                    ));
+                    let feedback = crate::client::types::CombatFeedback::AttackerNotification {
+                        defender_name: data.defender_name.clone(),
+                        damage_type: data.damage_type,
+                        health_percent: data.health_percent,
+                        damage: data.damage,
+                        critical_hit: data.critical_hit,
+                        attack_conditions: data.attack_conditions,
+                    };
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
                     Ok(())
                 }
                 GameEvent::DefenderNotification(data) => {
-                    self.emit_wire_event(WireEvent::CombatFeedback(
-                        crate::client::types::CombatFeedback::DefenderNotification {
-                            attacker_name: data.attacker_name.clone(),
-                            damage_type: data.damage_type,
-                            health_percent: data.health_percent,
-                            damage: data.damage,
-                            damage_location: data.damage_location,
-                            critical_hit: data.critical_hit,
-                            attack_conditions: data.attack_conditions,
-                        },
-                    ));
+                    let feedback = crate::client::types::CombatFeedback::DefenderNotification {
+                        attacker_name: data.attacker_name.clone(),
+                        damage_type: data.damage_type,
+                        health_percent: data.health_percent,
+                        damage: data.damage,
+                        damage_location: data.damage_location,
+                        critical_hit: data.critical_hit,
+                        attack_conditions: data.attack_conditions,
+                    };
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
                     Ok(())
                 }
                 GameEvent::EvasionAttackerNotification(data) => {
-                    self.emit_wire_event(WireEvent::CombatFeedback(
-                        crate::client::types::CombatFeedback::EvasionAttackerNotification {
-                            defender_name: data.defender_name.clone(),
-                        },
-                    ));
+                    let feedback = crate::client::types::CombatFeedback::EvasionAttackerNotification {
+                        defender_name: data.defender_name.clone(),
+                    };
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
                     Ok(())
                 }
                 GameEvent::EvasionDefenderNotification(data) => {
-                    self.emit_wire_event(WireEvent::CombatFeedback(
-                        crate::client::types::CombatFeedback::EvasionDefenderNotification {
-                            attacker_name: data.attacker_name.clone(),
-                        },
-                    ));
+                    let feedback = crate::client::types::CombatFeedback::EvasionDefenderNotification {
+                        attacker_name: data.attacker_name.clone(),
+                    };
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
                     Ok(())
                 }
                 GameEvent::CombatCommenceAttack => {
-                    self.emit_wire_event(WireEvent::CombatFeedback(
+                    let _ = self.client_view_event_tx.send(ClientViewEvent::CombatFeedback(
                         crate::client::types::CombatFeedback::AttackCommenced,
                     ));
                     Ok(())
                 }
                 GameEvent::VictimNotification(data) => {
-                    self.emit_wire_event(WireEvent::CombatFeedback(
-                        crate::client::types::CombatFeedback::VictimNotification {
-                            death_message: data.death_message.clone(),
-                        },
-                    ));
+                    let feedback = crate::client::types::CombatFeedback::VictimNotification {
+                        death_message: data.death_message.clone(),
+                    };
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
                     Ok(())
                 }
                 GameEvent::KillerNotification(data) => {
-                    self.emit_wire_event(WireEvent::CombatFeedback(
-                        crate::client::types::CombatFeedback::KillerNotification {
-                            death_message: data.death_message.clone(),
-                        },
-                    ));
+                    let feedback = crate::client::types::CombatFeedback::KillerNotification {
+                        death_message: data.death_message.clone(),
+                    };
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::CombatFeedback(feedback.clone()));
                     Ok(())
                 }
                 GameEvent::WeenieError(data) => {
                     self.note_busy_error(data.error, None);
-                    self.emit_wire_event(WireEvent::WeenieError {
-                        error: data.error,
-                        parameter: None,
-                    });
+                    self.emit_action_result(
+                        ActionResultSource::Wire,
+                        ActionResultReason::Weenie(data.error, None),
+                    );
                     Ok(())
                 }
                 GameEvent::WeenieErrorWithString(data) => {
                     self.note_busy_error(data.error, Some(data.parameter.clone()));
-                    self.emit_wire_event(WireEvent::WeenieError {
-                        error: data.error,
-                        parameter: Some(data.parameter.clone()),
-                    });
+                    self.emit_action_result(
+                        ActionResultSource::Wire,
+                        ActionResultReason::Weenie(data.error, Some(data.parameter.clone())),
+                    );
                     Ok(())
                 }
                 GameEvent::InventoryServerSaveFailed(data) => {
-                    self.emit_wire_event(WireEvent::InventoryServerSaveFailed {
-                        item_guid: data.item_guid,
-                        error: data.error,
-                    });
+                    self.emit_action_result(
+                        ActionResultSource::Wire,
+                        ActionResultReason::InventoryServerSaveFailed {
+                            item_guid: data.item_guid,
+                            error: data.error,
+                        },
+                    );
                     Ok(())
                 }
                 GameEvent::UseDone(data) => {
                     self.finish_busy_operation_from_use_done(data.error);
-                    self.emit_wire_event(WireEvent::UseDone { error: data.error });
+                    if data.error != WeenieError::None {
+                        self.emit_action_result(
+                            ActionResultSource::Wire,
+                            ActionResultReason::Weenie(data.error, None),
+                        );
+                    }
                     Ok(())
                 }
                 GameEvent::RegisterTrade(data) => {
@@ -377,18 +395,21 @@ impl ClientRuntime {
                         .get(partner_guid)
                         .map(|e: &Entity| e.name().to_string())
                         .unwrap_or_else(|| format!("0x{:08X}", partner_guid.0));
-                    self.emit_wire_event(WireEvent::ServerMessage {
-                        message: format!("Trade started with {}.", partner_name),
-                        chat_type: ChatMessageType::System as u32,
+                    let message = format!("Trade started with {}.", partner_name);
+                    let _ = self.client_view_event_tx.send(ClientViewEvent::ServerMessage {
+                        message: message.clone(),
+                        chat_type: (ChatMessageType::System as u32).into(),
                     });
                     Ok(())
                 }
                 GameEvent::QueryItemManaResponse(data) => {
-                    self.emit_wire_event(WireEvent::ItemManaResponse {
-                        target: ev.target,
-                        mana: data.mana,
-                        success: data.success,
-                    });
+                    let _ = self
+                        .client_view_event_tx
+                        .send(ClientViewEvent::ItemManaResponse {
+                            target: ev.target,
+                            mana: data.mana,
+                            success: data.success,
+                        });
                     Ok(())
                 }
                 _ => Ok(()),
@@ -417,7 +438,7 @@ impl ClientRuntime {
                         }
                     });
 
-                self.emit_wire_event(WireEvent::PlayerEntered {
+                let _ = self.client_view_event_tx.send(ClientViewEvent::PlayerEntered {
                     guid: player_id,
                     name: name.clone(),
                 });
@@ -427,13 +448,14 @@ impl ClientRuntime {
                 Ok(())
             }
             GameMessage::PlayerKilled(data) => {
-                self.emit_wire_event(WireEvent::CombatFeedback(
-                    crate::client::types::CombatFeedback::PlayerKilled {
-                        death_message: data.death_message.clone(),
-                        victim_id: data.victim_id,
-                        killer_id: data.killer_id,
-                    },
-                ));
+                let feedback = crate::client::types::CombatFeedback::PlayerKilled {
+                    death_message: data.death_message.clone(),
+                    victim_id: data.victim_id,
+                    killer_id: data.killer_id,
+                };
+                let _ = self
+                    .client_view_event_tx
+                    .send(ClientViewEvent::CombatFeedback(feedback.clone()));
                 Ok(())
             }
             GameMessage::PlayerTeleport(data) => {
@@ -449,9 +471,9 @@ impl ClientRuntime {
             }
             GameMessage::GameAction(data) => self.handle_game_action(&data.action).await,
             GameMessage::ServerMessage(data) => {
-                self.emit_wire_event(WireEvent::ServerMessage {
+                let _ = self.client_view_event_tx.send(ClientViewEvent::ServerMessage {
                     message: data.message.clone(),
-                    chat_type: data.chat_type,
+                    chat_type: data.chat_type.into(),
                 });
                 Ok(())
             }
@@ -459,14 +481,19 @@ impl ClientRuntime {
                 let error = self
                     .character_selection
                     .handle_character_error(data.error_id);
-                self.emit_wire_event(WireEvent::CharacterError(error));
+                self.emit_action_result(
+                    ActionResultSource::Wire,
+                    ActionResultReason::Character(error),
+                );
                 Ok(())
             }
             GameMessage::AccountBoot(data) => {
                 let reason = self.character_selection.handle_boot_account(*data);
                 self.state = ClientState::Disconnected;
                 self.send_status_event();
-                self.emit_wire_event(WireEvent::BootAccount(reason));
+                let _ = self
+                    .client_view_event_tx
+                    .send(ClientViewEvent::BootAccount(reason.clone()));
                 Ok(())
             }
             GameMessage::DddInterrogation => {
@@ -484,30 +511,30 @@ impl ClientRuntime {
                 } else {
                     data.sender_name.clone()
                 };
-                self.emit_wire_event(WireEvent::Chat {
-                    sender,
+                let _ = self.client_view_event_tx.send(ClientViewEvent::Chat {
+                    sender: sender.clone(),
                     message: data.message.clone(),
-                    chat_type: data.chat_type,
+                    chat_type: data.chat_type.into(),
                 });
                 Ok(())
             }
             GameMessage::HearRangedSpeech(data) => {
-                self.emit_wire_event(WireEvent::Chat {
+                let _ = self.client_view_event_tx.send(ClientViewEvent::Chat {
                     sender: data.sender_name.clone(),
                     message: data.message.clone(),
-                    chat_type: data.chat_type,
+                    chat_type: data.chat_type.into(),
                 });
                 Ok(())
             }
             GameMessage::EmoteText(data) => {
-                self.emit_wire_event(WireEvent::Emote {
+                let _ = self.client_view_event_tx.send(ClientViewEvent::Emote {
                     sender: data.sender_name.clone(),
                     text: data.text.clone(),
                 });
                 Ok(())
             }
             GameMessage::SoulEmote(data) => {
-                self.emit_wire_event(WireEvent::Emote {
+                let _ = self.client_view_event_tx.send(ClientViewEvent::Emote {
                     sender: data.sender_name.clone(),
                     text: data.text.clone(),
                 });
@@ -522,8 +549,10 @@ impl ClientRuntime {
                     ..
                 } = &data.payload
                 {
-                    self.emit_wire_event(WireEvent::ChannelMessage {
-                        channel: ChatChannelInfo::turbine(*channel, *chat_type, data.dispatch_type),
+                    let channel_info =
+                        ChatChannelInfo::turbine(*channel, *chat_type, data.dispatch_type);
+                    let _ = self.client_view_event_tx.send(ClientViewEvent::ChannelMessage {
+                        channel: channel_info,
                         sender: sender_name.clone(),
                         message: message.clone(),
                     });
@@ -950,7 +979,6 @@ mod tests {
     #[tokio::test]
     async fn test_character_create_response_projects_pending_operation() {
         let mut client = build_test_client();
-        let mut wire_events = client.subscribe_wire_events();
         let mut view_events = client.subscribe_client_view_events();
         client.character_selection.pending_character_operation =
             Some(CharacterManagementOperation::Create);
@@ -965,24 +993,6 @@ mod tests {
         )));
 
         client.handle_message(&encoded).await.unwrap();
-
-        let mut saw_wire = false;
-        while let Ok(event) = wire_events.try_recv() {
-            if matches!(
-                event,
-                WireEvent::CharacterManagementResponse {
-                    operation: Some(CharacterManagementOperation::Create),
-                    response: CharacterCreateResponseData {
-                        response: CharacterGenerationVerificationResponse::Ok,
-                        ..
-                    },
-                }
-            ) {
-                saw_wire = true;
-                break;
-            }
-        }
-        assert!(saw_wire);
 
         let mut saw_view = false;
         while let Ok(event) = view_events.try_recv() {
@@ -1006,7 +1016,6 @@ mod tests {
     #[tokio::test]
     async fn test_character_delete_response_projects_event() {
         let mut client = build_test_client();
-        let mut wire_events = client.subscribe_wire_events();
         let mut view_events = client.subscribe_client_view_events();
         client.character_selection.pending_character_operation =
             Some(CharacterManagementOperation::Delete);
@@ -1014,19 +1023,6 @@ mod tests {
         let encoded = encode_message(&GameMessage::CharacterDeleteResponse);
 
         client.handle_message(&encoded).await.unwrap();
-
-        assert!(matches!(
-            wire_events.try_recv(),
-            Ok(WireEvent::RawMessage(_))
-        ));
-        let mut saw_wire = false;
-        while let Ok(event) = wire_events.try_recv() {
-            if matches!(event, WireEvent::CharacterDeleteResponse) {
-                saw_wire = true;
-                break;
-            }
-        }
-        assert!(saw_wire);
 
         let mut saw_view = false;
         while let Ok(event) = view_events.try_recv() {

--- a/crates/holtburger-core/src/client/mod.rs
+++ b/crates/holtburger-core/src/client/mod.rs
@@ -38,10 +38,9 @@ pub struct ClientRuntime {
     active_confirmation: Option<ActiveCharacterConfirmation>,
     active_busy_operation: Option<PendingBusyOperation>,
     state: ClientState,
-    wire_event_tx: broadcast::Sender<WireEvent>,
     client_view_event_tx: broadcast::Sender<ClientViewEvent>,
     command_rx: Option<mpsc::UnboundedReceiver<ClientCommand>>,
-    pub message_dump_dir: Option<std::path::PathBuf>,
+    message_dump_dir: Option<std::path::PathBuf>,
     message_counter: usize,
     movement: MovementSystem,
     simulation: ClientSimulationSystem,
@@ -95,6 +94,22 @@ impl ClientRuntime {
         let _ = self
             .client_view_event_tx
             .send(ClientViewEvent::BusyOperationFinished { operation, result });
+    }
+
+    pub(super) fn emit_action_result(
+        &self,
+        source: ActionResultSource,
+        reason: ActionResultReason,
+    ) {
+        let _ = self
+            .client_view_event_tx
+            .send(ClientViewEvent::ActionResult { source, reason });
+    }
+
+    pub(super) fn emit_log_message(&self, message: String) {
+        let _ = self
+            .client_view_event_tx
+            .send(ClientViewEvent::LogMessage(message));
     }
 
     fn emit_self_movement_kinematics_updated(&self) {
@@ -202,10 +217,6 @@ impl ClientRuntime {
         self.emit_runtime_body_snapshot();
     }
 
-    pub fn subscribe_wire_events(&self) -> broadcast::Receiver<WireEvent> {
-        self.wire_event_tx.subscribe()
-    }
-
     pub fn subscribe_client_view_events(&self) -> broadcast::Receiver<ClientViewEvent> {
         self.client_view_event_tx.subscribe()
     }
@@ -215,181 +226,11 @@ impl ClientRuntime {
     }
 
     fn send_status_event(&self) {
-        self.emit_wire_event(WireEvent::StatusUpdate {
-            state: self.state.clone(),
-        });
-    }
-
-    pub fn emit_wire_event(&self, event: WireEvent) {
-        // New ClientView stream projection (normalization)
-        match &event {
-            WireEvent::StatusUpdate { state } => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::StatusUpdate {
-                        state: state.clone(),
-                    });
-            }
-            WireEvent::InventoryServerSaveFailed { item_guid, error } => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::ActionResult {
-                        source: ActionResultSource::Wire,
-                        reason: ActionResultReason::InventoryServerSaveFailed {
-                            item_guid: *item_guid,
-                            error: *error,
-                        },
-                    });
-            }
-            WireEvent::WeenieError { error, parameter } => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::ActionResult {
-                        source: ActionResultSource::Wire,
-                        reason: ActionResultReason::Weenie(*error, parameter.clone()),
-                    });
-            }
-            WireEvent::CharacterError(err) => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::ActionResult {
-                        source: ActionResultSource::Wire,
-                        reason: ActionResultReason::Character(*err),
-                    });
-            }
-            WireEvent::ClientError(msg) => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::ActionResult {
-                        source: ActionResultSource::Client,
-                        reason: ActionResultReason::General(msg.clone()),
-                    });
-            }
-            WireEvent::UseDone { error } if *error != WeenieError::None => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::ActionResult {
-                        source: ActionResultSource::Wire,
-                        reason: ActionResultReason::Weenie(*error, None),
-                    });
-            }
-            WireEvent::CombatFeedback(feedback) => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::CombatFeedback(feedback.clone()));
-            }
-            WireEvent::ServerMessage { message, chat_type } => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::ServerMessage {
-                        message: message.clone(),
-                        chat_type: (*chat_type).into(),
-                    });
-            }
-            WireEvent::Chat {
-                sender,
-                message,
-                chat_type,
-            } => {
-                let _ = self.client_view_event_tx.send(ClientViewEvent::Chat {
-                    sender: sender.clone(),
-                    message: message.clone(),
-                    chat_type: (*chat_type).into(),
-                });
-            }
-            WireEvent::ChannelMessage {
-                channel,
-                sender,
-                message,
-            } => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::ChannelMessage {
-                        channel: *channel,
-                        sender: sender.clone(),
-                        message: message.clone(),
-                    });
-            }
-            WireEvent::Tell { sender, message } => {
-                let _ = self.client_view_event_tx.send(ClientViewEvent::Tell {
-                    sender: sender.clone(),
-                    message: message.clone(),
-                });
-            }
-            WireEvent::CharacterList(list) => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::CharacterList(list.clone()));
-            }
-            WireEvent::CharacterManagementResponse {
-                operation,
-                response,
-            } => {
-                let _ =
-                    self.client_view_event_tx
-                        .send(ClientViewEvent::CharacterManagementResponse {
-                            operation: *operation,
-                            response: response.clone(),
-                        });
-            }
-            WireEvent::CharacterDeleteResponse => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::CharacterDeleteResponse);
-            }
-            WireEvent::PlayerEntered { guid, name } => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::PlayerEntered {
-                        guid: *guid,
-                        name: name.clone(),
-                    });
-            }
-            WireEvent::ItemManaResponse {
-                target,
-                mana,
-                success,
-            } => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::ItemManaResponse {
-                        target: *target,
-                        mana: *mana,
-                        success: *success,
-                    });
-            }
-            WireEvent::GameMessage(msg) => {
-                if let holtburger_protocol::messages::GameMessage::ServerName(data) = &**msg {
-                    let _ = self
-                        .client_view_event_tx
-                        .send(ClientViewEvent::WorldNameUpdated(data.name.clone()));
-                }
-            }
-            WireEvent::Emote { sender, text } => {
-                let _ = self.client_view_event_tx.send(ClientViewEvent::Emote {
-                    sender: sender.clone(),
-                    text: text.clone(),
-                });
-            }
-            WireEvent::PingResponse => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::PingResponse);
-            }
-            WireEvent::LogMessage(msg) => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::LogMessage(msg.clone()));
-            }
-            WireEvent::BootAccount(reason) => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::BootAccount(reason.clone()));
-            }
-            _ => {}
-        }
-
-        let _ = self.wire_event_tx.send(event);
+        let _ = self
+            .client_view_event_tx
+            .send(ClientViewEvent::StatusUpdate {
+                state: self.state.clone(),
+            });
     }
 
     pub fn handle_world_event(&self, event: &WorldEvent) {
@@ -887,10 +728,13 @@ mod tests {
         let mut events = client.subscribe_client_view_events();
         let item_guid = Guid(0x4000_0001);
 
-        client.emit_wire_event(WireEvent::InventoryServerSaveFailed {
-            item_guid,
-            error: holtburger_protocol::errors::WeenieError::YoureTooBusy,
-        });
+        client.emit_action_result(
+            ActionResultSource::Wire,
+            ActionResultReason::InventoryServerSaveFailed {
+                item_guid,
+                error: holtburger_protocol::errors::WeenieError::YoureTooBusy,
+            },
+        );
 
         let mut saw_projected_event = false;
         while let Ok(event) = events.try_recv() {

--- a/crates/holtburger-core/src/client/mod.rs
+++ b/crates/holtburger-core/src/client/mod.rs
@@ -676,11 +676,6 @@ impl ClientRuntime {
                     .client_view_event_tx
                     .send(ClientViewEvent::CombatModeUpdated { mode: *mode });
             }
-            WorldEvent::NoClipUpdated(enabled) => {
-                let _ = self
-                    .client_view_event_tx
-                    .send(ClientViewEvent::NoClipUpdated { enabled: *enabled });
-            }
             WorldEvent::VendorStateUpdated(vendor) => {
                 let _ = self
                     .client_view_event_tx

--- a/crates/holtburger-core/src/client/types.rs
+++ b/crates/holtburger-core/src/client/types.rs
@@ -13,9 +13,8 @@ use holtburger_protocol::messages::movement::MovementEventData;
 use holtburger_protocol::messages::trade::actions::ItemProfileActionData;
 use holtburger_protocol::messages::{
     CharacterCreateRequestData, CharacterCreateResponseData, CharacterEntry, ChatChannel,
-    ChatChannelId, ChatMessageTypeId, GameMessage, SetTurbineChatChannelsEventData,
-    TurbineChatChannel, TurbineChatChannelId, TurbineChatDispatchType, TurbineChatType,
-    TurbineChatTypeId, ViewContentsEventItem,
+    ChatChannelId, ChatMessageTypeId, SetTurbineChatChannelsEventData, TurbineChatChannel,
+    TurbineChatChannelId, TurbineChatDispatchType, TurbineChatType, TurbineChatTypeId,
 };
 use holtburger_world::FellowshipActivity;
 use holtburger_world::SelfMovementKinematics;
@@ -180,73 +179,6 @@ pub enum CharacterManagementOperation {
     Create,
     Delete,
     Restore,
-}
-
-#[derive(Debug, Clone)]
-pub enum WireEvent {
-    CharacterList(Vec<CharacterEntry>),
-    CharacterManagementResponse {
-        operation: Option<CharacterManagementOperation>,
-        response: CharacterCreateResponseData,
-    },
-    CharacterDeleteResponse,
-    PlayerEntered {
-        guid: Guid,
-        name: String,
-    },
-    StatusUpdate {
-        state: ClientState,
-    },
-    ServerMessage {
-        message: String,
-        chat_type: u32,
-    },
-    CharacterError(CharacterError),
-    ClientError(String),
-    WeenieError {
-        error: WeenieError,
-        parameter: Option<String>,
-    },
-    InventoryServerSaveFailed {
-        item_guid: Guid,
-        error: WeenieError,
-    },
-    BootAccount(String),
-    GameMessage(Box<GameMessage>),
-    Chat {
-        sender: String,
-        message: String,
-        chat_type: u32,
-    },
-    ChannelMessage {
-        channel: ChatChannelInfo,
-        sender: String,
-        message: String,
-    },
-    Tell {
-        sender: String,
-        message: String,
-    },
-    Emote {
-        sender: String,
-        text: String,
-    },
-    PingResponse,
-    ViewContents {
-        container: Guid,
-        items: Vec<ViewContentsEventItem>,
-    },
-    ItemManaResponse {
-        target: Guid,
-        mana: f32,
-        success: u32,
-    },
-    RawMessage(Vec<u8>),
-    LogMessage(String),
-    UseDone {
-        error: WeenieError,
-    },
-    CombatFeedback(CombatFeedback),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/holtburger-core/src/client/types.rs
+++ b/crates/holtburger-core/src/client/types.rs
@@ -436,9 +436,6 @@ pub enum ClientViewEvent {
     CombatModeUpdated {
         mode: CombatMode,
     },
-    NoClipUpdated {
-        enabled: bool,
-    },
     VendorStateUpdated {
         vendor: Option<VendorState>,
     },

--- a/crates/holtburger-core/src/lib.rs
+++ b/crates/holtburger-core/src/lib.rs
@@ -9,6 +9,6 @@ pub use client::runtime_body_view_cache::RuntimeBodyViewCache;
 pub use client::types::{
     ActionResultReason, ActionResultSource, ActiveCharacterConfirmation, BusyOperationKind,
     BusyOperationResult, ClientCommand, ClientState, ClientViewEvent, PlayerCharacterOptions,
-    RetryState, WireEvent,
+    RetryState,
 };
 pub use client::{ClientRuntime, ClientRuntimeBuilder};

--- a/crates/holtburger-debug-harness/ARCHITECTURE.md
+++ b/crates/holtburger-debug-harness/ARCHITECTURE.md
@@ -4,7 +4,7 @@ The `holtburger-debug-harness` is a bespoke, headless, non-interactive integrati
 
 ## Core Philosophical Principles
 - **Programmable Scenarios**: Allows developers to script exact "Walk to point A, cast spell B, verify server response C" workflows through code.
-- **Headless Execution**: Bypasses rendering loops and UI state projections. It executes strictly against the `ClientViewEvent` standard or even lower `WireEvent`/`WorldEvent` layers if debugging core network mechanics.
+- **Headless Execution**: Bypasses rendering loops and UI state projections. It executes strictly against `ClientViewEvent` plus explicit diagnostic configuration when raw packet dumps are needed.
 - **Isolate and Diagnose**: Before complex data translation bugs get obfuscated by UI projection (lossy design), you can halt execution right at the protocol translation boundary here.
 
 ## Key Components
@@ -13,7 +13,7 @@ The `holtburger-debug-harness` is a bespoke, headless, non-interactive integrati
 Contains the main binary entry points that instantiate a `ClientBuilder`, establish connections to dynamic local or public servers, and await explicit programmatic exit conditions.
 
 ### 2. Integration Scaffolding ([src/lib.rs](src/lib.rs))
-Exposes the helpers and mock environments needed to spoof credentials, generate realistic player load, and dump `WireEvent` packets directly to disk (using `message_dump_dir`).
+Exposes the helpers and mock environments needed to spoof credentials, generate realistic player load, and dump raw reassembled message bytes directly to disk via `ClientRuntimeBuilder::message_dump_dir(...)`.
 
 ## Use Cases
 

--- a/crates/holtburger-debug-harness/src/bin/extractor.rs
+++ b/crates/holtburger-debug-harness/src/bin/extractor.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use holtburger_content::ContentRepository;
-use holtburger_core::{ClientCommand, ClientRuntimeBuilder, WireEvent};
+use holtburger_core::{ClientCommand, ClientRuntimeBuilder, ClientViewEvent};
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -55,7 +55,6 @@ async fn main() -> Result<()> {
     println!("Message Extractor starting...");
     println!("Dumping messages to: {}", out_dir.display());
 
-    let (event_tx, mut event_rx) = mpsc::unbounded_channel();
     let (command_tx, command_rx) = mpsc::unbounded_channel();
 
     let content = if dats_path.is_dir() {
@@ -66,22 +65,11 @@ async fn main() -> Result<()> {
     let mut builder =
         ClientRuntimeBuilder::new(args.account.clone()).server(args.server.clone(), args.port);
     builder.load_assets(&content)?;
+    builder = builder.message_dump_dir(out_dir.clone());
 
     let mut client = builder.connect().await?;
-
-    client.message_dump_dir = Some(out_dir);
-    let mut wire_rx = client.subscribe_wire_events();
+    let mut view_rx = client.subscribe_client_view_events();
     client.set_command_rx(command_rx);
-
-    // Forward broadcast to mpsc for the loop
-    let event_tx_inner = event_tx.clone();
-    tokio::spawn(async move {
-        while let Ok(event) = wire_rx.recv().await {
-            if event_tx_inner.send(event).is_err() {
-                break;
-            }
-        }
-    });
 
     let _ = command_tx.send(ClientCommand::Login(args.password.clone()));
     let mut client_handle = tokio::spawn(async move {
@@ -99,8 +87,11 @@ async fn main() -> Result<()> {
 
     loop {
         tokio::select! {
-            Some(event) = event_rx.recv() => {
-                if let WireEvent::CharacterList(chars) = event {
+            result = view_rx.recv() => {
+                let Ok(event) = result else {
+                    break;
+                };
+                if let ClientViewEvent::CharacterList(chars) = event {
                     println!("Characters received:");
                     for entry in &chars { println!("  - {} ({:08X})", entry.name, entry.guid); }
 

--- a/crates/holtburger-session/ARCHITECTURE.md
+++ b/crates/holtburger-session/ARCHITECTURE.md
@@ -25,21 +25,17 @@ The connection begins plaintext, securely executes an RSA handshake, and transit
 sequenceDiagram
     participant Srv as Server
     participant Sess as Session Layer
-    participant Proto as Protocol Layer (Binrw)
     participant Core as Engine
 
     Srv->>Sess: UDP Fragment (Encrypted)
     Sess->>Sess: Decrypt & Track Sequence
     Sess->>Sess: Reassemble Complete Payload
-    Sess->>Proto: Bytes
-    Proto->>Sess: Unpacked GameMessage
-    Sess->>Core: WireEvent (Raw Protocol Message)
+    Sess->>Core: Message Bytes
 ```
 
 1. **Receive**: Decrypts raw UDP bytes.
 2. **Reassemble**: Combines fragments based on sequence ordering.
-3. **Parse**: Uses `holtburger-protocol` to convert the `[u8]` slice into strongly typed `holtburger_protocol::messages::GameMessage` objects.
-4. **Emit**: Hands the discrete protocol message upward as a `WireEvent` to the Core Engine for state manipulation.
+3. **Emit**: Hands each reassembled payload upward as bytes so core can decode it into `holtburger_protocol::messages::GameMessage` at the core/world boundary.
 
 ## 🛠️ Developer Onboarding
 

--- a/crates/holtburger-session/src/session/tests.rs
+++ b/crates/holtburger-session/src/session/tests.rs
@@ -465,7 +465,7 @@ fn test_payload_hash_multi_fragment_unaligned_matches_wire_layout() {
 }
 
 #[tokio::test]
-async fn test_request_retransmit_replays_cached_packet() {
+async fn test_request_retransmit_sends_cached_packet() {
     let requested_sequence = 9u32;
     let retransmit_payload = [1u32.to_le_bytes(), requested_sequence.to_le_bytes()].concat();
     let transport = ScriptedTransport::new(

--- a/crates/holtburger-world/src/events.rs
+++ b/crates/holtburger-world/src/events.rs
@@ -119,7 +119,6 @@ pub enum WorldEvent {
         spell_ids: Vec<u32>,
     },
     CombatModeUpdated(holtburger_protocol::messages::combat::CombatMode),
-    NoClipUpdated(bool),
     ServerTimeUpdate(f64),
     TeleportStarted {
         sequence: u16,

--- a/crates/holtburger-world/src/player/types.rs
+++ b/crates/holtburger-world/src/player/types.rs
@@ -257,8 +257,6 @@ pub struct PlayerState {
     pub spellbook_filters: u32,
     /// Opaque gameplay options blob retained from PlayerDescription.
     pub gameplay_options: Vec<u8>,
-    /// Whether collision detection is disabled for movement.
-    pub noclip: bool,
 
     /// Flat set of all item GUIDs currently owned by the player (in pack or containers).
     pub inventory: HashSet<Guid>,
@@ -301,7 +299,6 @@ impl PlayerState {
             desired_comps: Vec::new(),
             spellbook_filters: 0,
             gameplay_options: Vec::new(),
-            noclip: false,
             inventory: HashSet::new(),
             equipment: HashMap::new(),
             last_emitted_derived_stats: None,

--- a/docs/plans/wire-event-removal-refactor-plan.md
+++ b/docs/plans/wire-event-removal-refactor-plan.md
@@ -1,0 +1,353 @@
+# WireEvent Removal Refactor Plan
+
+## Context And Boundaries
+
+### Goal
+Remove `WireEvent` as `holtburger-core`'s mixed-responsibility event bus, preserve the current `session -> core -> world -> core -> tui` authority split, and fold replay removal into the same refactor so the remaining event surfaces are honest and minimal.
+
+### In Scope
+- Remove `WireEvent` from the normal core-to-frontend/runtime flow.
+- Remove replay-era public runtime/event plumbing that no longer earns its keep.
+- Keep `holtburger-world` consuming decoded protocol messages directly; do not introduce a new DTO layer between core and world.
+- Preserve current observable client behavior for the TUI and scripts via `ClientViewEvent`.
+- Preserve a deliberate low-level message dump/debug path if we still need raw bytes for diagnostics.
+- Update the debug harness so it no longer depends on `WireEvent`.
+- Update architecture docs and any stale references that claim `WireEvent` is the main session->core protocol surface.
+
+### Out Of Scope
+- Re-architecting `holtburger-world` to stop consuming `GameMessage`.
+- Rewriting session reliability/retransmit internals.
+- Designing a brand new generic observability framework for every crate.
+- Changing protocol layouts in `holtburger-protocol`.
+- Refactoring unrelated `ClientViewEvent` shape issues unless they block `WireEvent` removal.
+- Preserving full debug-harness behavior during the refactor. Harness fallout is acceptable if it simplifies the main runtime cleanup.
+
+## Ground Truth And Existing Patterns
+
+### Reference Sources
+- Current `WireEvent` and `ClientViewEvent` definitions in [crates/holtburger-core/src/client/types.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/types.rs)
+- Current `WireEvent` projection bridge in [crates/holtburger-core/src/client/mod.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/mod.rs)
+- Current message decode and `WireEvent` emission flow in [crates/holtburger-core/src/client/messages.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/messages.rs)
+- Current command-side synthetic `WireEvent` usage in [crates/holtburger-core/src/client/commands.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/commands.rs)
+- Current session surface in [crates/holtburger-session/src/session/types.rs](/home/me/code/holtburger/crates/holtburger-session/src/session/types.rs) and [crates/holtburger-session/src/session/receive.rs](/home/me/code/holtburger/crates/holtburger-session/src/session/receive.rs)
+- Current world boundary in [crates/holtburger-world/ARCHITECTURE.md](/home/me/code/holtburger/crates/holtburger-world/ARCHITECTURE.md)
+- Current debug harness dependency on `WireEvent` and `message_dump_dir` in [crates/holtburger-debug-harness/src/bin/extractor.rs](/home/me/code/holtburger/crates/holtburger-debug-harness/src/bin/extractor.rs)
+- Current core architecture claims in [crates/holtburger-core/ARCHITECTURE.md](/home/me/code/holtburger/crates/holtburger-core/ARCHITECTURE.md)
+
+### Existing Patterns To Follow
+- Keep `holtburger-session` responsible for transport, ordering, fragmentation, retransmit, and time-sync only.
+- Keep `holtburger-world` authoritative for decoded gameplay/state mutations, not transport concerns.
+- Keep `holtburger-core` as the orchestrator that decodes session payloads, routes to world, and projects frontend-facing deltas.
+- Prefer one honest event surface per audience over one overloaded bus with misleading names.
+- If a low-level debugging surface remains, keep it explicitly diagnostic rather than quietly reusing the main app event channel.
+
+## Dry-Run Findings Against The Current Codebase
+
+### `WireEvent` Is Not Actually A Wire-Only Surface
+The enum in [crates/holtburger-core/src/client/types.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/types.rs) mixes:
+
+- protocol-derived messages such as `GameMessage`, `RawMessage`, and `ViewContents`
+- normalized semantic outcomes such as `CombatFeedback`, `Chat`, and `CharacterList`
+- purely client-synthesized events such as `ClientError` and `LogMessage`
+
+That makes the type name misleading and invites misuse.
+
+### Core Currently Uses `WireEvent` As A Normalization Bridge
+`ClientRuntime::emit_wire_event()` in [crates/holtburger-core/src/client/mod.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/mod.rs) immediately projects many `WireEvent` variants into `ClientViewEvent` and then rebroadcasts the original `WireEvent`. This means `WireEvent` is currently serving as an internal staging bus rather than a true externally meaningful abstraction.
+
+### Commands Emit Fake "Wire" Events
+`commands.rs` emits `WireEvent::ClientError` and `WireEvent::LogMessage` in [crates/holtburger-core/src/client/commands.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/commands.rs). These are not packet-derived and are the clearest proof that `WireEvent` has drifted into a generic misc-event bus.
+
+### Session Does Not Currently Expose Decoded Protocol Messages
+`holtburger-session` currently yields `SessionEvent::Message(Vec<u8>)` and `SessionEvent::TimeSync(f64)` in [crates/holtburger-session/src/session/types.rs](/home/me/code/holtburger/crates/holtburger-session/src/session/types.rs). Core performs `GameMessage` unpacking itself in [crates/holtburger-core/src/client/messages.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/messages.rs). So removing `WireEvent` does not require changing the world boundary first.
+
+### World Already Has The Right Upstream Boundary
+`holtburger-world` consumes decoded `GameMessage` values and emits `WorldEvent` as documented in [crates/holtburger-world/ARCHITECTURE.md](/home/me/code/holtburger/crates/holtburger-world/ARCHITECTURE.md). That means we do not gain much by inventing a new DTO between core and world just to make the dependency graph look cleaner.
+
+### Replay Removal Lowers The Value Of A Raw Broadcast Bus
+Replay-oriented construction is already considered dead in earlier planning, and the main remaining low-level seam is the packet/message extractor path via [crates/holtburger-debug-harness/src/bin/extractor.rs](/home/me/code/holtburger/crates/holtburger-debug-harness/src/bin/extractor.rs) plus `message_dump_dir`. Once replay is intentionally removed, `WireEvent` loses one of its last semi-legitimate reasons to exist as a public surface.
+
+### The Debug Harness Still Needs A Replacement Story
+The extractor currently uses two different seams:
+
+- `message_dump_dir` for raw message bytes
+- `subscribe_wire_events()` for character-list detection and control flow
+
+That means `WireEvent` cannot simply be deleted in one diff without replacing at least the control-flow portion if we want to preserve extractor behavior. That preservation is now explicitly low priority, so extractor breakage is acceptable during the main cleanup as long as the runtime/event architecture lands cleanly.
+
+### `subscribe_wire_events()` Has Very Few Real Consumers
+The current `subscribe_wire_events()` call sites are limited to:
+
+- core tests in [crates/holtburger-core/src/client/messages.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/messages.rs)
+- core tests in [crates/holtburger-core/src/client/commands.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/commands.rs)
+- the extractor harness in [crates/holtburger-debug-harness/src/bin/extractor.rs](/home/me/code/holtburger/crates/holtburger-debug-harness/src/bin/extractor.rs)
+
+There do not appear to be ordinary runtime/front-end consumers of `WireEvent`. That materially improves the task ordering: we can refactor the core runtime toward direct `ClientViewEvent` emission first, then migrate tests and the extractor, and only then remove the public `WireEvent` surface.
+
+### Architecture Docs Have Drifted From The Code
+The core and session architecture docs still talk as if `WireEvent` is the main protocol event surface from session into core. The current code does not match that description. The refactor should use the code as ground truth and then update the docs to match the new shape.
+
+## Variant Migration Matrix
+
+This matrix is the concrete dry-run output for Phase 1. It exists to keep the refactor honest and to prevent us from deleting `WireEvent` only to recreate it under a different name.
+
+| `WireEvent` variant | Current producer(s) | Current consumer(s) | Recommended destination |
+| --- | --- | --- | --- |
+| `RawMessage(Vec<u8>)` | `client/messages.rs` on every inbound payload | core message tests | remove from runtime bus; preserve only through explicit raw dump/diagnostic sink if still needed |
+| `GameMessage(Box<GameMessage>)` | `client/messages.rs` after decode | `emit_wire_event()` projects `ServerName`; otherwise no meaningful runtime consumer | delete from runtime bus; handle special cases directly during decode |
+| `CharacterList` | `client/messages.rs` | `emit_wire_event()`, extractor, tests | emit `ClientViewEvent::CharacterList` directly |
+| `CharacterManagementResponse` | `client/messages.rs` | `emit_wire_event()`, tests | emit `ClientViewEvent::CharacterManagementResponse` directly |
+| `CharacterDeleteResponse` | `client/messages.rs` | `emit_wire_event()`, tests | emit `ClientViewEvent::CharacterDeleteResponse` directly |
+| `PlayerEntered` | `client/messages.rs` | `emit_wire_event()` | emit `ClientViewEvent::PlayerEntered` directly |
+| `StatusUpdate` | `client/mod.rs` | `emit_wire_event()` | emit `ClientViewEvent::StatusUpdate` directly |
+| `ServerMessage` | `client/messages.rs` | `emit_wire_event()` | emit `ClientViewEvent::ServerMessage` directly |
+| `Chat` | `client/messages.rs` | `emit_wire_event()` | emit `ClientViewEvent::Chat` directly |
+| `ChannelMessage` | `client/messages.rs` | `emit_wire_event()` | emit `ClientViewEvent::ChannelMessage` directly |
+| `Tell` | `client/messages.rs` | `emit_wire_event()` | emit `ClientViewEvent::Tell` directly |
+| `Emote` | `client/messages.rs` | `emit_wire_event()` | emit `ClientViewEvent::Emote` directly |
+| `PingResponse` | `client/messages.rs` | `emit_wire_event()` | emit `ClientViewEvent::PingResponse` directly |
+| `ItemManaResponse` | `client/messages.rs` | `emit_wire_event()` | emit `ClientViewEvent::ItemManaResponse` directly |
+| `CombatFeedback` | `client/messages.rs` | `emit_wire_event()` | emit `ClientViewEvent::CombatFeedback` directly |
+| `BootAccount` | `client/messages.rs` | `emit_wire_event()` | emit `ClientViewEvent::BootAccount` directly |
+| `WeenieError` | `client/messages.rs` | `emit_wire_event()` currently maps to `ActionResult`; `ClientViewEvent::WeenieError` exists but is not the active projection path | emit `ClientViewEvent::ActionResult` directly; treat the standalone `ClientViewEvent::WeenieError` shape as follow-up cleanup if it remains unused |
+| `InventoryServerSaveFailed` | `client/messages.rs`, one core test helper in `client/mod.rs` | `emit_wire_event()` maps to `ActionResult` | emit `ClientViewEvent::ActionResult` directly |
+| `CharacterError` | `client/messages.rs` | `emit_wire_event()` maps to `ActionResult` | emit `ClientViewEvent::ActionResult` directly |
+| `UseDone` | `client/messages.rs` | `emit_wire_event()` only maps non-`None` values to `ActionResult` | handle directly inside message processing / busy-operation logic; no separate bus variant needed |
+| `ClientError` | `client/commands.rs` | `emit_wire_event()` maps to `ActionResult` | remove first; emit `ClientViewEvent::ActionResult` directly |
+| `LogMessage` | `client/commands.rs` | `emit_wire_event()`, command tests | remove first; emit `ClientViewEvent::LogMessage` directly |
+| `ViewContents` | `client/messages.rs` | no projection in `emit_wire_event()` and no active subscriber surfaced by the dry run | delete unless a concrete consumer still exists; world already handles the decoded message |
+
+## Natural Task Scheduling Adjustments From The Dry Run
+
+The codebase suggests a cleaner execution order than a naive "delete enum and fix compile errors" approach.
+
+### 1. Remove Fake `WireEvent` Variants Before Touching Packet-Derived Ones
+`ClientError` and `LogMessage` are the least defensible variants and have the narrowest blast radius. They should move first because they do not depend on any decode-path refactor.
+
+### 2. Migrate Test Expectations Alongside Each Slice
+Several tests in [crates/holtburger-core/src/client/messages.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/messages.rs) and [crates/holtburger-core/src/client/commands.rs](/home/me/code/holtburger/crates/holtburger-core/src/client/commands.rs) currently assert both wire and view emission. Those should be converted incrementally to assert only the surviving semantic surface for each migrated slice, rather than left for one giant cleanup at the end.
+
+### 3. Leave Raw Diagnostics Until The End
+`RawMessage` and any surviving message-dump facility should be the last step. They are the only plausible reason a low-level seam might still exist after replay removal, so deleting them early would create churn without clarifying the architecture.
+
+### 4. Collapse `GameMessage` As A Special Case During Decode, Not Via A New Bus
+The only currently observed semantic projection from `WireEvent::GameMessage` is `WorldNameUpdated` for `GameMessage::ServerName`. That is a sign to move that projection into the decode/message-handling path directly instead of preserving a generic decoded-message event layer.
+
+## Recommended Architecture
+
+### Core Principle
+Split event surfaces by audience, not by historical accident.
+
+- `SessionEvent`: transport/session internals only
+- `GameMessage`: decoded protocol input owned by the core->world boundary
+- `WorldEvent`: authoritative world mutation outcomes
+- `ClientViewEvent`: frontend/script/harness semantic feed
+- optional diagnostic sink: explicit raw-packet/raw-message observability, only if still needed
+
+### Proposed Runtime Shape
+
+#### 1. Remove `WireEvent` From The Main Runtime API
+`ClientRuntime` should stop publishing `WireEvent` as a general broadcast surface. Core should instead:
+
+- decode session bytes into `GameMessage`
+- route decoded messages to direct core handlers and `WorldState::handle_message()`
+- emit `ClientViewEvent` directly for frontend-facing semantics
+- emit `WorldEvent` projections directly into `ClientViewEvent`
+
+This removes the current "emit wire event, immediately re-project it" double hop.
+
+#### 2. Keep World On `GameMessage`
+Do not insert a new core-owned DTO layer between core and world in this refactor. That would mostly move the routing duplication rather than remove it.
+
+#### 3. Replace Raw `WireEvent` Needs With Narrower Seams
+Anything still needed after `WireEvent` removal should become one of:
+
+- direct `ClientViewEvent` emission for UI-visible semantics
+- a private helper path for action-result/log/status emission inside core
+- a dedicated diagnostic callback or sink for raw bytes / decoded messages, if packet extraction still matters
+
+If the extractor only needs raw byte dumps plus `CharacterList`, that is much narrower than the current full `WireEvent` bus.
+
+#### 4. Treat Replay Removal As Part Of The Same Cleanup
+Replay-era plumbing should not be preserved behind a renamed abstraction. If replay is dead, remove replay-based construction and any event surfaces that only existed to support it.
+
+## Phased Implementation
+
+### Phase 1: Finalize And Validate `WireEvent` Responsibility Inventory
+
+#### Deliverables
+- Validate the existing dry-run matrix against any hidden consumers or edge cases and lock the remaining decisions.
+- Ensure every current `WireEvent` variant is classified as one of:
+  - raw diagnostic
+  - decoded protocol observation
+  - normalized semantic event
+  - client-generated misc event
+- Confirm all `subscribe_wire_events()` consumers and what they actually need.
+- Decide which responsibilities survive the refactor and which are deleted with replay/removal.
+
+#### Acceptance Criteria
+- Every `WireEvent` variant has an explicit replacement target or deletion decision.
+- Every current subscriber has an explicit migration target.
+- No variant remains in the "we will figure it out later" bucket.
+
+### Phase 2: Remove Synthetic Non-Wire Usage First
+
+#### Deliverables
+- Replace `WireEvent::ClientError`, `WireEvent::LogMessage`, and similar command-generated usage with direct `ClientViewEvent` emission or private helper methods inside core.
+- Introduce small helper methods in `ClientRuntime` for recurring direct view-event emission where needed.
+- Keep behavior unchanged from the TUI/script consumer perspective.
+
+#### Acceptance Criteria
+- `commands.rs` no longer emits fake `WireEvent` values for client-generated logs/errors.
+- The remaining `WireEvent` usages, if any, are strictly packet-derived or deliberately diagnostic.
+- Narrow tests for touched command/view-event behavior pass.
+
+### Phase 3: Collapse The `emit_wire_event()` Bridge
+
+#### Deliverables
+- Replace `emit_wire_event()` call sites in core message handling with direct `ClientViewEvent` emission and direct internal state handling.
+- Remove the broad `match` projection in `ClientRuntime::emit_wire_event()`.
+- Keep any necessary decode-local helpers small and explicit rather than rebuilding a new catch-all bus under a different name.
+
+#### Acceptance Criteria
+- Normal frontend-visible semantics flow directly into `ClientViewEvent` without bouncing through `WireEvent`.
+- Core no longer needs a public `subscribe_wire_events()` path for ordinary runtime behavior.
+- `WireEvent` is either gone or reduced to an explicitly diagnostic private/internal type.
+
+### Phase 4: Remove Replay-Era Public Plumbing And Optionally Repair Harnesses
+
+#### Deliverables
+- Remove replay-era public construction/event plumbing encountered in core/session during the refactor so we do not preserve dead seams behind the new architecture.
+- Preserve raw message dumping through `message_dump_dir` or replace it with a narrower explicit diagnostic sink if that is cleaner.
+- If worth the effort, update [crates/holtburger-debug-harness/src/bin/extractor.rs](/home/me/code/holtburger/crates/holtburger-debug-harness/src/bin/extractor.rs) to stop depending on `WireEvent` and use `ClientViewEvent::CharacterList` or another explicit semantic signal for control flow.
+
+#### Acceptance Criteria
+- Replay-era public runtime/event plumbing is removed rather than hidden behind compatibility shims.
+- Any remaining low-level diagnostic seam is explicit and narrow.
+- If the extractor is touched in this phase, it no longer depends on `subscribe_wire_events()`.
+
+#### Priority Note
+This phase is intentionally lower priority than the main runtime cleanup. If removing `WireEvent` cleanly causes temporary extractor regressions, that is acceptable. Harness restoration should not block deleting the mixed-responsibility runtime event surface.
+
+### Phase 5: Remove `WireEvent` Public Surface And Dead Code
+
+#### Deliverables
+- Delete `WireEvent` and `subscribe_wire_events()` if no diagnostic public API remains necessary.
+- Remove `wire_event_tx` and associated runtime plumbing from `ClientRuntime`.
+- Remove dead tests, helpers, and imports that existed only to support `WireEvent`.
+- Update architecture docs in core/session/debug-harness to match the new event flow.
+
+#### Acceptance Criteria
+- `holtburger-core` no longer exports `WireEvent` as part of the runtime API.
+- The documented runtime flow matches the code: session bytes -> core decode -> world -> world/core projections -> `ClientViewEvent`.
+- `cargo test` for touched crates passes.
+
+## Risks And Mitigations
+
+### Risk 1: We Accidentally Delete Useful Diagnostics Along With Replay
+The current overloaded bus makes it easy to lose raw observability when simplifying the API.
+
+Mitigation:
+- classify raw diagnostic needs explicitly in Phase 1
+- keep `message_dump_dir` or replace it with a narrow diagnostic sink before deleting `WireEvent`
+- do not couple diagnostic deletion to the same patch as semantic event rewiring unless the replacement already exists
+
+### Risk 2: View-Event Behavior Regresses Because The Current Bridge Hides Ordering
+`emit_wire_event()` currently centralizes some ordering and projection behavior.
+
+Mitigation:
+- migrate one local slice at a time
+- validate with narrow tests around touched message/command flows
+- prefer small helper methods over broad rewrites so ordering stays explicit
+
+### Risk 3: Docs And Harnesses Lag The Refactor
+This repo already has stale architecture prose around the session/core event boundary.
+
+Mitigation:
+- treat docs as first-class deliverables, not cleanup if time permits
+- finish with a doc audit across core and session surfaces, and update debug-harness docs if that tool is still meant to be supported afterward
+
+Adjusted priority for this refactor:
+- documentation remains first-class because it defines the architecture contract
+- debug-harness recovery is explicitly allowed to lag if needed
+
+### Risk 4: We Recreate `WireEvent` Under A New Name
+If we remove the type but keep one universal intermediate bus, the architecture does not really improve.
+
+Mitigation:
+- require every surviving event surface to name its audience explicitly
+- reject catch-all replacements unless they are strictly diagnostic and narrowly scoped
+
+## Definition Of Done
+
+- `WireEvent` is deleted or reduced to a private/narrow diagnostic seam with no frontend/runtime semantic role.
+- `holtburger-core` emits `ClientViewEvent` directly for frontend-visible semantics.
+- `holtburger-world` still consumes `GameMessage` directly and no new DTO layer is added between core and world.
+- Replay-era public construction/event plumbing is removed.
+- Core/session architecture docs describe the actual event flow accurately.
+- If the debug harness remains in active use after the refactor, it no longer depends on `subscribe_wire_events()`.
+- Focused tests for touched crates pass.
+
+## Living Worksheet
+
+### Task Checklist
+- [x] Phase 1: Finalize and validate the `WireEvent` inventory and migration matrix.
+- [x] Phase 2: Remove synthetic client-generated `WireEvent` usage.
+- [x] Phase 3: Replace bridge-style `emit_wire_event()` projections with direct `ClientViewEvent` emission.
+- [x] Phase 4: Remove replay-era public plumbing and optionally repair harness tooling.
+- [x] Phase 5: Delete `WireEvent` public API and update docs.
+
+### Decisions Log
+- Decision: keep `holtburger-world` on `GameMessage`; no new DTO layer between core and world in this refactor.
+- Decision: treat replay removal as in-scope because it materially reduces the need for a raw event bus.
+- Decision: preserve low-level diagnostics only through a narrow explicit seam, not through a mixed runtime event type.
+- Decision: Phase 2 removes `WireEvent::ClientError` and `WireEvent::LogMessage` outright instead of preserving them as renamed compatibility variants.
+- Decision: command-generated errors/log output now go straight to `ClientViewEvent` through small `ClientRuntime` helpers (`emit_action_result`, `emit_log_message`) rather than bouncing through the wire bus.
+- Decision: Phase 3 moves message/status-side `ClientViewEvent` projection to the producer paths (`messages.rs` plus `send_status_event`) instead of keeping any projection logic inside `emit_wire_event()`.
+- Decision: `emit_wire_event()` now acts only as the remaining `WireEvent` rebroadcast seam for tests/debug consumers; it no longer has frontend semantic responsibilities.
+- Decision: Phase 4/5 deletes `WireEvent` entirely instead of preserving a private diagnostic event enum, because the remaining consumer need was fully covered by direct `ClientViewEvent` semantics plus raw byte dumping.
+- Decision: raw message dumping survives, but only as explicit builder configuration via `ClientRuntimeBuilder::message_dump_dir(...)`; the mutable runtime field is no longer part of the public API.
+- Decision: the debug harness now treats `ClientViewEvent::CharacterList` as its control-flow signal and uses builder-configured raw message dumps for packet capture.
+
+### Verification Log
+- Completed Phase 1 in planning/doc analysis:
+  - validated the full `WireEvent` variant inventory against the current codebase
+  - confirmed the remaining subscribers and their actual needs before implementation began
+  - locked the migration matrix that drove Phases 2 through 5
+- Completed Phase 2 in core:
+  - removed `WireEvent::ClientError` and `WireEvent::LogMessage`
+  - moved command-side emission to direct `ClientViewEvent` helpers in `ClientRuntime`
+  - updated the fellowship status command test to read from `ClientViewEvent`
+  - added a command test covering the missing-confirmation client error path
+- Completed Phase 3 in core:
+  - removed the `ClientViewEvent` projection match from `ClientRuntime::emit_wire_event()`
+  - moved status updates to direct `ClientViewEvent::StatusUpdate` emission before any wire rebroadcast
+  - moved message-side semantic projection in `client/messages.rs` to direct `ClientViewEvent` emission for character selection flow, chat/server messages, combat feedback, action results, boot/status cases, and world-name updates
+  - updated the mod-level action-result projection test so it asserts the new direct path instead of `emit_wire_event()` side effects
+- Completed Phase 4/5 in core and harness:
+  - deleted `WireEvent`, `subscribe_wire_events()`, `wire_event_tx`, and all remaining wire-bus rebroadcast logic from `holtburger-core`
+  - removed the last message-side `emit_wire_event()` calls and migrated the remaining message tests to assert only `ClientViewEvent`
+  - moved raw message dump configuration from `ClientRuntime.message_dump_dir` to `ClientRuntimeBuilder::message_dump_dir(...)`
+  - updated the extractor harness to use `ClientViewEvent::CharacterList` for control flow while preserving raw dump capture through builder configuration
+  - updated core/session/debug-harness architecture docs to describe the post-`WireEvent` event flow accurately
+- Validation:
+  - `cargo test -p holtburger-core command`
+  - `cargo test -p holtburger-core messages`
+  - `cargo test -p holtburger-core client`
+  - `cargo check -p holtburger-debug-harness`
+  - no editor errors in the touched core files
+
+### Course-Correct Check
+- No course correction needed before Phase 3.
+- The Phase 2 result matches the plan's intended shape: remaining `WireEvent` usage in core is no longer command-generated misc output.
+- Watch item for Phase 3: keep the new direct-emission helpers narrow and resist turning them into another generic intermediate bus.
+- No course correction needed after Phase 3.
+- The runtime/frontend semantic path no longer depends on `emit_wire_event()` normalization; that bridge has been collapsed as planned.
+- Watch item for Phase 4/5: `WireEvent` still rebroadcasts many packet-derived semantic events for tests/debug consumers, so the next phases must delete or narrow that public seam rather than letting the temporary duplication become permanent.
+- No course correction needed after Phase 5.
+- The mixed-responsibility runtime event surface is now fully gone from code and public exports.
+- Remaining watch item is documentation drift outside the touched architecture files, not an architectural blocker in the runtime itself.
+
+### Open Questions
+- Resolved: raw byte dump support is sufficient for the surviving diagnostic need in this refactor; we did not keep a public decoded-message diagnostic stream.
+- Resolved: the surviving diagnostic sink now lives in builder/config construction through `ClientRuntimeBuilder::message_dump_dir(...)`.


### PR DESCRIPTION
This pull request removes the legacy noclip debug feature and the internal `WireEvent` bus, simplifying the event model and improving the architecture documentation. It also introduces an explicit `message_dump_dir` option for diagnostics, clarifies the event flow from protocol to UI, and cleans up related code and documentation. The changes focus on making the core engine's event handling more direct and less error-prone, while removing dead code and improving maintainability.

**Architecture and Event Model Simplification:**

* Removed the internal `WireEvent` bus and its usages, consolidating all frontend-facing events into `ClientViewEvent` for a cleaner, more direct event model. Updated documentation and diagrams in `ARCHITECTURE.md` to reflect this streamlined flow from protocol decoding to UI deltas, and clarified that low-level packet dumps are now handled via `message_dump_dir` instead of a public event bus. [[1]](diffhunk://#diff-721d8bb430ebb951a796ba98dc26aa0d8c88d7c962016f513f3d6caf89ccb825L18-R28) [[2]](diffhunk://#diff-721d8bb430ebb951a796ba98dc26aa0d8c88d7c962016f513f3d6caf89ccb825L141-R156) [[3]](diffhunk://#diff-721d8bb430ebb951a796ba98dc26aa0d8c88d7c962016f513f3d6caf89ccb825L164-R166) [[4]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL101) [[5]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL111-R111) [[6]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL124-R124)

* Added a `message_dump_dir` option to `ClientRuntimeBuilder` to enable explicit diagnostic packet dumping, removing the need for a general-purpose runtime event bus for raw protocol data. [[1]](diffhunk://#diff-08a85ef55ff83545a48e4e1f686b815d2ed44498b2e817da06d4a1d49a9d6ec7R6) [[2]](diffhunk://#diff-08a85ef55ff83545a48e4e1f686b815d2ed44498b2e817da06d4a1d49a9d6ec7R27) [[3]](diffhunk://#diff-08a85ef55ff83545a48e4e1f686b815d2ed44498b2e817da06d4a1d49a9d6ec7R37) [[4]](diffhunk://#diff-08a85ef55ff83545a48e4e1f686b815d2ed44498b2e817da06d4a1d49a9d6ec7R83-R87) [[5]](diffhunk://#diff-08a85ef55ff83545a48e4e1f686b815d2ed44498b2e817da06d4a1d49a9d6ec7L114) [[6]](diffhunk://#diff-08a85ef55ff83545a48e4e1f686b815d2ed44498b2e817da06d4a1d49a9d6ec7L123-R132) [[7]](diffhunk://#diff-08a85ef55ff83545a48e4e1f686b815d2ed44498b2e817da06d4a1d49a9d6ec7L138) [[8]](diffhunk://#diff-08a85ef55ff83545a48e4e1f686b815d2ed44498b2e817da06d4a1d49a9d6ec7L147)

**Dead Code and Debug Feature Removal:**

* Removed the noclip debug feature from `GameData`, its default implementation, and all related event handling and TODO entries, as it was unused and considered dead code. [[1]](diffhunk://#diff-d038459a24b6ffe543ed768787615a5534c1186e7a5886b66339b8cd5be8bf64L306-L307) [[2]](diffhunk://#diff-d038459a24b6ffe543ed768787615a5534c1186e7a5886b66339b8cd5be8bf64L349) [[3]](diffhunk://#diff-2cf46fa104a17652f034e0cef943a73307441791664cb7d2f5249e476a813366L110-L117) [[4]](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986R94-L106) [[5]](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986L271-R271)

**Refactoring and Test Updates:**

* Refactored command handling in `ClientRuntime` to emit user-facing results and logs through `ClientViewEvent` instead of the removed `WireEvent`, and updated associated tests accordingly. [[1]](diffhunk://#diff-36846f1dea6bc88af8b5a6e53de3c30f321a3f6508be5c92b1618554391c0c2bL1-R3) [[2]](diffhunk://#diff-36846f1dea6bc88af8b5a6e53de3c30f321a3f6508be5c92b1618554391c0c2bL319-R327) [[3]](diffhunk://#diff-36846f1dea6bc88af8b5a6e53de3c30f321a3f6508be5c92b1618554391c0c2bL625-R635) [[4]](diffhunk://#diff-36846f1dea6bc88af8b5a6e53de3c30f321a3f6508be5c92b1618554391c0c2bL1028-R1036) [[5]](diffhunk://#diff-36846f1dea6bc88af8b5a6e53de3c30f321a3f6508be5c92b1618554391c0c2bL1227-R1235) [[6]](diffhunk://#diff-36846f1dea6bc88af8b5a6e53de3c30f321a3f6508be5c92b1618554391c0c2bL1804-R1821)

**Submodule Update:**

* Updated the `ACE` submodule to a new commit.